### PR TITLE
fix mounting of tarballs on enter-chroot script

### DIFF
--- a/enter-chroot
+++ b/enter-chroot
@@ -10,6 +10,8 @@ fi
 export H="$PWD"
 . "$H"/config
 
+mkdir -p "$R"/src/tarballs
+
 mount --rbind /dev "$R"/dev
 mount --rbind /proc "$R"/proc
 mount --bind "$C" "$R"/src/tarballs


### PR DESCRIPTION
sorry for this, I missed this somewhere, simple fix though.
