### PR TITLE
Fixed missing dependency for xkeyboard-config

### DIFF
--- a/pkg/xkeyboard-config
+++ b/pkg/xkeyboard-config
@@ -1,6 +1,7 @@
 [deps]
 intltool
 gettext
+xkbcomp
 
 [main]
 filesize=559151


### PR DESCRIPTION
xkeyboard-config needed xkbcomb to install, added
required dependency in pkg file.
