### PR TITLE
Give /var/tmp the same permissions as /tmp.

### DIFF
--- a/utils/prepare-rootfs
+++ b/utils/prepare-rootfs
@@ -30,6 +30,7 @@ ln -s . usr
 ln -s bin sbin
 
 chmod 1777 tmp var/tmp
+chmod 700 root
 
 cp -r "$K"/etc/* "$R"/etc/
 cp -r "$K"/bin/* "$R"/bin/


### PR DESCRIPTION
Programs that try to create files under /var/tmp were failing
when run as an unprivileged user because of incorrect perms.
