### PR TITLE
bump znc version from 1.0 to 1.2

### DIFF
--- a/KEEP/znc.patch
+++ b/KEEP/znc.patch
@@ -1,28 +1,28 @@
---- a/include/znc/Csocket.h	2012-11-06 16:02:20.000000000 +0000
-+++ b/include/znc/Csocket.h	2013-08-13 00:15:33.000000000 +0000
-@@ -46,7 +46,7 @@
+--- a/include/znc/Csocket.h
++++ b/include/znc/Csocket.h
+@@ -45,7 +45,7 @@
+ #include <stdio.h>
  #include <unistd.h>
  #include <sys/time.h>
- #include <sys/types.h>
 -#include <sys/fcntl.h>
 +#include <fcntl.h>
  #include <sys/file.h>
  
  #ifndef _WIN32
---- a/include/znc/FileUtils.h	2012-11-06 16:02:20.000000000 +0000
-+++ b/include/znc/FileUtils.h	2013-08-13 00:15:44.000000000 +0000
-@@ -14,7 +14,7 @@
+--- a/include/znc/FileUtils.h
++++ b/include/znc/FileUtils.h
+@@ -22,7 +22,7 @@
  #include <dirent.h>
  #include <stdlib.h>
  #include <string.h>
 -#include <sys/fcntl.h>
 +#include <fcntl.h>
+ #include <sys/stat.h>
  #include <unistd.h>
  #include <vector>
- 
---- a/src/Csocket.cpp	2012-11-06 16:02:20.000000000 +0000
-+++ b/src/Csocket.cpp	2013-08-13 05:07:35.000000000 +0000
-@@ -584,12 +584,8 @@
+--- a/src/Csocket.cpp
++++ b/src/Csocket.cpp
+@@ -613,12 +613,8 @@
  	return( strerror( iErrno ) );
  #else
  	memset( pszBuff, '\0', uBuffLen );

--- a/pkg/znc
+++ b/pkg/znc
@@ -1,9 +1,9 @@
 [main]
-filesize=1222361
-sha512=4219cdd32296e5851f6cd99a8ac6e14d2579df10e8e111bb09d6c3789e400e2fcdc173968afd54808d286f0fb4945aa57d2d0f3b62a20e761de64500c8938e35
+filesize=1235150
+sha512=dff24e56127e5599d64b4c62de967d5d48d8ebf23ca8597d33bf0b3622640512db7a462bfa7c2031cd8307f402bab8efa345f6d1fc813e78eb0dcae581de3cf7
 
 [mirrors]
-http://znc.in/releases/znc-1.0.tar.gz
+http://znc.in/releases/znc-1.2.tar.gz
 
 [deps]
 openssl
@@ -15,3 +15,4 @@ LDFLAGS="$optldflags" \
   ./configure --prefix="$butch_prefix" || exit 1
 make -j$MAKE_THREADS || exit 1
 make DESTDIR="$butch_install_dir" install || exit 1
+  


### PR DESCRIPTION
This updates the znc package (filesize, url and sha512sum) as well as the patch needed to build it
