### PR TITLE
webkitgtk1: update to 1.10.2

### DIFF
--- a/KEEP/webkitgtk1-assert.patch
+++ b/KEEP/webkitgtk1-assert.patch
@@ -1,19 +1,21 @@
---- a/Source/JavaScriptCore/wtf/Assertions.cpp
-+++ b/Source/JavaScriptCore/wtf/Assertions.cpp
-@@ -52,7 +52,7 @@
- #include <windows.h>
- #endif
- 
--#if OS(DARWIN) || OS(LINUX)
-+#if OS(DARWIN) || (OS(LINUX) && __GLIBC__)
+--- a/Source/WTF/wtf/Assertions.cpp
++++ b/Source/WTF/wtf/Assertions.cpp
+@@ -61,8 +61,10 @@
+ #if (OS(DARWIN) || OS(LINUX)) && !OS(ANDROID)
  #include <cxxabi.h>
  #include <dlfcn.h>
++#ifdef __GLIBC__
  #include <execinfo.h>
-@@ -249,7 +249,7 @@
+ #endif
++#endif
+ 
+ #if OS(ANDROID)
+ #include "android/log.h"
+@@ -268,7 +270,7 @@
  
  void WTFGetBacktrace(void** stack, int* size)
  {
--#if OS(DARWIN) || OS(LINUX)
+-#if (OS(DARWIN) || OS(LINUX)) && !OS(ANDROID)
 +#if OS(DARWIN) || (OS(LINUX) && __GLIBC__)
      *size = backtrace(stack, *size);
  #elif OS(WINDOWS) && !OS(WINCE)

--- a/pkg/webkitgtk1
+++ b/pkg/webkitgtk1
@@ -1,9 +1,9 @@
 [mirrors]
-http://webkitgtk.org/releases/webkit-1.8.3.tar.xz
+http://webkitgtk.org/releases/webkitgtk-1.10.2.tar.xz
 
 [main]
-filesize=7814028
-sha512=4d400cb0dfbde7eadcce52e7a37d2095ec382b65c6c0d4ea4795410dabad771fac0def50875092634075dc0a80043058d2d2913767e59db3e32cf3e13361803f
+filesize=8633640
+sha512=0c2909eabdc9532619d6486cd42f18a4eb4868c02be3f1c62a6d11d2cb23b4d5a84dd9b60fc353a25134c4ecd8f7cc9f75690bfc17a0360fd4a4c1f4f07aac8f
 
 [deps]
 gperf
@@ -23,7 +23,7 @@ sed -i '/generate-gtkdoc --rebase/s:^:# :' GNUmakefile.in
 sed -i '/parse-param/ a%lex-param {YYLEX_PARAM}' \
              Source/ThirdParty/ANGLE/src/compiler/glslang.y
 CFLAGS=-D_GNU_SOURCE ./configure -C --prefix="$butch_prefix" \
-	--with-gtk=2.0 --disable-webkit2 --disable-geolocation \
+	--with-gtk=2.0 --disable-webkit2 --disable-jit --disable-geolocation \
 	|| exit 1
 make -j$MAKE_THREADS || exit 1
 make DESTDIR="$butch_install_dir" install || exit 1


### PR DESCRIPTION
This fixes several issues:
- "Copy link destination" did not work with X clipboard
- "Open in New Window" did not work as expected
- There was no "Open in New Tab"

Version 1.8.3 was used previously because the javascript on some
sites (gmail) was broken with 1.10.2 . By using --disable-jit, those sites
now work perfectly with this version. It feels a bit snappier as well.

Bonus: Score on http://html5test.com/ went from 329 to 347.
