### PR TITLE
Urxvt

### DIFF
--- a/pkg/urxvt
+++ b/pkg/urxvt
@@ -3,7 +3,7 @@ filesize=914096
 sha512=357f2b9a299b816264e8cece3200338369399e4f760622daec1520d05c75e93d44e2dee3351c8e31765ab8f2218dbb9d239960ae8112e2f75d988785373d7f26
 
 [mirrors]
-http://dist.schmorp.de/rxvt-unicode/rxvt-unicode-9.19.tar.bz2
+http://dist.schmorp.de/rxvt-unicode/Attic/rxvt-unicode-9.19.tar.bz2
 
 [deps]
 xorg-proto-headers


### PR DESCRIPTION
URL breaks if they bring out new versions.
Using the "Attic" directory should fix the problem.
