### PR TITLE
Adding 'haveged' entropy daemon package and service

### DIFF
--- a/KEEP/services/haveged
+++ b/KEEP/services/haveged
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec haveged -w 1024 -F 2>&1

--- a/pkg/haveged
+++ b/pkg/haveged
@@ -1,0 +1,19 @@
+[mirrors]
+http://www.issihosts.com/haveged/haveged-1.8.tar.gz
+
+[main]
+filesize=459893
+sha512=770ea9f4f47a0121ba4712269ab1f6796cf4522ab4a44f04b154f9c76732899ee01d747ff8e614e01be6f08726ed7d3b1429940960d810a2d7aa883eb9a849f0
+
+[deps]
+zlib
+
+[build]
+CFLAGS="$optcflags" \
+LDFLAGS="$optldflags" ./configure -C --prefix="$butch_prefix" || exit 1
+
+make -j$MAKE_THREADS || exit 1
+make DESTDIR="$butch_install_dir" install || exit 1
+
+IS="$K"/bin/install-service
+"$IS" --down --log haveged "$K"/services/haveged


### PR DESCRIPTION
Adding a sabotage package for 'haveged' - http://www.issihosts.com/haveged/index.html

Version 1.8 was recently released, builds cleanly with musl with no extra hacking required. 

I find this package lightweight and useful for systems that otherwise wouldn't have much randomness.

Hopefully I've done this whole pull-request thing right. Please let me know if I haven't, or how I can do it better. Cheers.
