### PR TITLE
Add pixman as a qemu dependency

### DIFF
--- a/pkg/qemu
+++ b/pkg/qemu
@@ -9,6 +9,7 @@ sha512=6ee52444b93fc2953e8080383cc0cdc618a826ddd5252bf5f6faf27d91699a414924d6015
 glib
 sdl
 libx11
+pixman
 
 [build]
 


### PR DESCRIPTION
Although qemu ships with its own copy of pixman it will not build it with the version of autotools in sabotage so it is simpler to just add as a dependency and it will use the external copy.
