### PR TITLE
python-pip needs wget

### DIFF
--- a/pkg/python-pip
+++ b/pkg/python-pip
@@ -7,6 +7,7 @@ sha512=b969797d4c93aabefa4b66e0ad3d2c3ccedd3324e68bb1fa81d383f1e867d24ce2fb91851
 [deps]
 python
 setuptools
+wget
 
 [build]
 python setup.py build || exit 1


### PR DESCRIPTION
The download URL now redirects to https, which the busybox wget cannot cope with, so need the real wget.
