### PR TITLE
Update rsync to 3.1.1

### DIFF
--- a/pkg/rsync
+++ b/pkg/rsync
@@ -1,9 +1,9 @@
 [mirrors]
-http://rsync.samba.org/ftp/rsync/rsync-3.1.0.tar.gz
+http://rsync.samba.org/ftp/rsync/rsync-3.1.1.tar.gz
 
 [main]
-filesize=883901
-sha512=bc8dfc90cac1a83cbb34e33cea805bfaa9597694a285fb69d55224fc52987c0199415b380f83a6ac55d17548e6888d1ab0d7bb5951ae4c3a3412c4e3ccf932f3
+filesize=890124
+sha512=ec0e46ff532a09a711282aaa822f5f1c133593ee6c1c474acd67284619236e6a202f0f369d3e67a95ceb3a3b1c39ea7fb609d6d6fb950f3be6e0f6372e903e21
 
 [deps]
 


### PR DESCRIPTION
rsync 3.1.0 is no longer available from the site
