### PR TITLE
gcc474 needs bash to x-compile on stage1

### DIFF
--- a/KEEP/gcc-474-ltmain_nofail.patch
+++ b/KEEP/gcc-474-ltmain_nofail.patch
@@ -1,0 +1,10 @@
+--- gcc-4.7.4.old/ltmain.sh
++++ gcc-4.7.4/ltmain.sh
+@@ -1150,6 +1150,7 @@
+     for cmd in $1; do
+       IFS=$save_ifs
+       eval "cmd=\"$cmd\""
++      [ -z "$cmd" ] && continue
+       func_show_eval "$cmd" "${2-:}"
+     done
+     IFS=$save_ifs

--- a/pkg/gcc474
+++ b/pkg/gcc474
@@ -35,6 +35,7 @@ patch -p1 < "$K"/gcc473-arm-hwcap.patch
 patch -p1 < "$K"/gcc473-config-sub.patch
 patch -p1 < "$K"/gcc473-powerpc-libc-stack-end.patch
 patch -p1 < "$K"/gcc-474-universal-initializer-no-warning.patch
+patch -p1 < "$K"/gcc-474-ltmain_nofail.patch
 
 # fix specs file generation. this prevents libgcc_s from being used.
 # not only is it slower, it'll cause assertion errors in ld.
@@ -94,6 +95,9 @@ machine=
 if [ -n "$CROSS_COMPILE" ] ; then
 	machine=$($CC -dumpmachine)
 	xconfflags="--host=$machine --target=$machine"
+	if [ "$A" = "arm" ]; then
+	  xconfflags="--disable-libssp $xconfflags"
+	fi
 	export GCC_FOR_TARGET="$CC"
 fi
 export CC="$CC -static -D_GNU_SOURCE"


### PR DESCRIPTION
This makes stage1 x-compile on a stage1 sabotage (weird: is bash not needed for non-xcompiling?)