### PR TITLE
stage1: Clean up bootstrap compiler and libc.

### DIFF
--- a/pkg/stage1
+++ b/pkg/stage1
@@ -11,3 +11,12 @@ musl
 dynamic-toolchain
 man
 zlib
+
+[build]
+rm -rf "$butch_root_dir"/opt/gcc3
+rm -rf "$butch_root_dir"/opt/stage0_musl
+rm -rf "$butch_root_dir"/opt/stage0
+rm -rf "$butch_root_dir"/opt/stage1
+
+butch unlink gcc3
+butch relink `ls -d "$butch_root_dir"/opt/gcc4* |awk -F/ '{print $NF}' |tail -n1`


### PR DESCRIPTION
This change shaves 12.1MB from the resulting stage1 build, a bit over an 8% savings.