### PR TITLE
add efi bootloader manager

### DIFF
--- a/KEEP/bin/dhclient
+++ b/KEEP/bin/dhclient
@@ -1,11 +1,39 @@
 #!/bin/sh
+
+usage() {
+    echo "usage: $0 [-nw] interface"
+    echo "The -nw flag enables daemon mode"
+    echo "i.e. $0 eth0"
+    echo "i.e. $0 -nw wlan0"
+}
+
 if [ -z "$1" ] ; then
-	echo usage: $0 [interface]
-	echo i.e. $0 eth0
-	echo i.e. $0 wlan0
+    usage
 	exit 1
 fi
-interface="$1"
-retries=1
-/sbin/udhcpc -t $retries -n -i "$interface" -s /etc/udhcpc-script
 
+extraopts=""
+retries=1
+
+if [ "$1" = '-nw' ]; then
+    if [ -z "$2" ] ; then
+        usage
+        exit 1
+    fi
+
+    extraopts="-A 10 -b"
+    shift
+fi
+
+interface="$1"
+mkdir -p /var/run/dhclient/
+if [ -f /var/run/dhclient/"$interface" ]; then
+  pid=$(cat /var/run/dhclient/"$interface")
+  if [ -n "$pid" ]; then
+    if [ -d /proc/"$pid" ]; then
+      kill -9 "$pid" || exit 1
+    fi
+  fi
+fi
+rm -f /var/run/dhclient/"$interface"
+/sbin/udhcpc $extraopts -p /var/run/dhclient/"$interface" -t $retries -i "$interface" -s /etc/udhcpc-script

--- a/KEEP/efivar-git.patch
+++ b/KEEP/efivar-git.patch
@@ -1,0 +1,14 @@
+--- efivar.orig/src/makeguids.c
++++ efivar/src/makeguids.c
+@@ -99,8 +99,9 @@
+ 	if (rc < 0)
+ 		err(1, "makeguids: could not read \"%s\"", argv[1]);
+ 
+-	/* strictly speaking, this *has* to be too large. */
+-	struct guidname *outbuf = calloc(inlen, sizeof (char));
++	/* strictly speaking, this *has* to be too large. Oh so you
++           think a struct takes as much space as a string? Mkay. */
++	struct guidname *outbuf = calloc(inlen, sizeof(char)*8);
+ 	if (!outbuf)
+ 		err(1, "makeguids");
+

--- a/KEEP/etc/wpa_connect_action.sh
+++ b/KEEP/etc/wpa_connect_action.sh
@@ -12,7 +12,7 @@ echo "$0: $if $state"
 case "$state" in
 CONNECTED)
 if $do_dhcp ; then
-	dhclient "$if" || dhclient "$if";
+	dhclient -nw "$if";
 else
 	sn=192.168.1
 	ifconfig "$if" "$sn".100 netmask 255.255.255.0

--- a/KEEP/initramfs.init
+++ b/KEEP/initramfs.init
@@ -12,7 +12,7 @@ fail_shell() {
 
 waitdev() {
   local dev=$1
-  for i in $(seq 10); do
+  for i in $(seq 20); do
     if echo "$dev" |grep -E -q '(UUID=|LABEL=)'; then
       tdev="$(findfs $dev)"
     fi
@@ -33,7 +33,7 @@ wait_btrfs() {
   btrfs device scan
   if [ ! -z "$btrfs" ]; then
     waitdev $btrfs
-    for i in $(seq 10); do
+    for i in $(seq 20); do
       if [ -b "$btrfs" ]; then
         break
       fi
@@ -41,8 +41,9 @@ wait_btrfs() {
       if [ ! -z "$fs" ]; then
         btrfs="$fs"
       fi
+      sleep 1
     done
-    for i in $(seq 10); do
+    for i in $(seq 20); do
       if btrfs device ready $btrfs; then
         break
       fi

--- a/KEEP/squash-tool
+++ b/KEEP/squash-tool
@@ -1071,7 +1071,12 @@ fi
 [ ! -x /bin/cpio ] && fail 'Please install cpio'
 
 case "$func" in
-  "install") installer "$@";; #TODO: efibootmgr
+  "install") installer "$@"
+             echo "If you are installing to an UEFI system"
+             echo "And are not booting from removable media"
+             echo "You should have efibootmgr installed"
+             echo "And run:"
+             echo "efibootmgr -c -d $1 -p 1 -l /efi/boot/bootx64.efi -L 'Sabotage' -w";;
   "tarball") mkboottar "$@";;
   "in_chroot") in_chroot "$@";;
   "mkinitramfs") mkinitramfs "$@";;

--- a/pkg/efibootmgr-git
+++ b/pkg/efibootmgr-git
@@ -1,0 +1,21 @@
+[deps]
+bash
+git
+pciutils
+zlib
+efivar-git
+perl
+
+[build]
+dest="$S/build/efibootmgr-git"
+mkdir -p "$dest"
+if [ -d "$dest/efibootmgr" ]; then
+	cd "$dest/efibootmgr"
+	git pull
+else
+	cd "$dest"
+	git clone -b efibootmgr-0.11.0 --depth=1 https://github.com/rhinstaller/efibootmgr.git efibootmgr
+	cd efibootmgr
+fi
+sed -i -r 's,sys/pci\.h,pci/pci.h,g' src/lib/scsi_ioctls.c
+make DESTDIR="$butch_install_dir" BINDIR="/bin" install

--- a/pkg/efivar-git
+++ b/pkg/efivar-git
@@ -1,0 +1,20 @@
+[deps]
+bash
+git
+popt
+perl
+
+[build]
+dest="$S/build/efivar-git"
+mkdir -p "$dest"
+if [ -d "$dest/efivar" ]; then
+	cd "$dest/efivar"
+	git pull
+else
+	cd "$dest"
+	git clone -b efivar-0.14 --depth=1 https://github.com/rhinstaller/efivar.git efivar
+	cd efivar
+fi
+patch -p1 < "$K"/efivar-git.patch
+make DESTDIR="$butch_install_dir" includedir="/include" bindir="/bin" libdir="/lib"  install
+ln -s ./libefivar.so.0 "$butch_install_dir"/lib/libefivar.so

--- a/pkg/kernel
+++ b/pkg/kernel
@@ -88,5 +88,13 @@ make V=1 ARCH=$A HOSTCFLAGS=-D_GNU_SOURCE INSTALL_HDR_PATH=dest \
 # remove junk from kernel headers
 find dest/include \( -name .install -o -name ..install.cmd \) -delete
 
+if egrep -q '\=m$' my.config; then
+  if [ -n "$ENABLE_GRSEC" ] ; then
+    v="$LINUX_VER"-grsec
+  else
+    v="$LINUX_VER"
+  fi
+  depmod "$v"
+fi
 
 exit 0

--- a/pkg/pciutils
+++ b/pkg/pciutils
@@ -16,3 +16,7 @@ patch -p1 < "$K"/pciutils-pread.patch
 make CFLAGS="-D_GNU_SOURCE -DHAVE_PREAD $optcflags" LDFLAGS="$optldflags" \
   PREFIX="$butch_prefix" DESTDIR="$butch_install_dir" \
   -j$MAKE_THREADS all install
+make CFLAGS="-D_GNU_SOURCE -DHAVE_PREAD $optcflags" LDFLAGS="$optldflags" \
+  PREFIX="$butch_prefix" DESTDIR="$butch_install_dir" \
+  -j$MAKE_THREADS install-lib
+

--- a/pkg/squash-tool
+++ b/pkg/squash-tool
@@ -9,4 +9,4 @@ cpio
 
 [build]
 install -D -m 750 "$K"/squash-tool "$butch_install_dir""$butch_prefix"/bin/squash-tool || exit 1
-#version e50288c5c25199f01264d3dbb39461354b7d9bdcd01dc96215bcb86054d8df7d10a9bf54a851445f79d5bfd78d08931f6a2e78ab883fab5709e38455fc20df33
+#version 911028ccff93e1796822c6e34763a0c16382ec2b5b7f9658711215068298093a4515a96bafaf5f4701872c9ddfaa4adbb31eb2baa5376a92ce625374359bc739


### PR DESCRIPTION
 * Efivars and efibootmanager are tools used to manipulate the UEFI boot entries. Efibotmgr is needed to install sabotage on an UEFI system without having to manually add the boot entry in the "bios" (if this is even possible, not all bioses have an entry editor)
 * the kernel package updates the modules.* files in /lib/$kver now (for modprobe)
 * dhclient's behavior was not reliable. this setup works far better for me.
 * initramfs wait time: some flakey usb key took more than 10 seconds to show up on one of my systems, so I hope 20 seconds should suffice for most use cases