### PR TITLE
build-stage0: Initialize SABOTAGE_BUILDDIR if it exists, but is empty.

### DIFF
--- a/build-stage0
+++ b/build-stage0
@@ -29,7 +29,7 @@ rm -f "$tmpc" "$tmpc".out
 mkdir -p "$C" 
 
 ### initialize chroot, if missing
-if [ ! -d "$R" ] ; then
+if [ ! -d "$R"/bin ] ; then
 	echo "$(date +'%F %T') initializing root system"
 
 	. "$H"/utils/setup-rootfs.sh


### PR DESCRIPTION
A user reported failure running build-stage0 against a pre-existing directory used for SABOTAGE_BUILDDIR. We now test for '/bin' being present under the assumption that if it is missing, likely the directory needs to be initialized. 