### PR TITLE
change the way boostrapping gcc is built

### DIFF
--- a/KEEP/config.cross
+++ b/KEEP/config.cross
@@ -2,18 +2,24 @@
 #export A=i386
 #export A=x86_64
 #export A=x86_64-x32
-#export A=arm
 #export A=mips
 #export A=powerpc
 #export A=microblaze
 #export A=sh
+#export A=arm
+# arch specific flags to pass to the gcc build
+# your crosscompiler should be configured equivalently
+# if not provided, will be derived from the crosscompiler config
+#export GCC_ARCH_CONFIG_FLAGS="--with-float=soft --with-fpu=vfp"
 
 [ -z "$A" ] && { printf "ERROR: no arch set\n" ; exit 1 ; }
+
+export ARCH=$A
 
 # set BRUTE to 1 to enable LTO in the standard etc/butch-optflags profile
 # (slow to compile, but results in minimal binary size and very fast code)
 #export BRUTE=1
-# set TESTBUILD to build everything without optimization/debug (much faster)
+# set TESTBUILD to 1 to build everything without optimization/debug (much faster)
 #export TESTBUILD=1
 
 # set to basepath containing your musl-cross toolchains

--- a/KEEP/config.local
+++ b/KEEP/config.local
@@ -17,11 +17,6 @@ export A=i386
 #export A=x86_64
 #export A=arm
 
-
-#export this only if you build for ARM, and set the right arch number (4-7)
-#export ARM_ARCH=6
-
-
 export CC=gcc
 export HOSTCC=gcc
 

--- a/KEEP/config.stage0
+++ b/KEEP/config.stage0
@@ -4,9 +4,15 @@ export SABOTAGE_BUILDDIR="/tmp/sabotage"
 ## set your arch, or try `uname -m`
 export A=i386
 #export A=x86_64
-#export A=arm
 #export A=mips
 #export A=powerpc
+#export A=arm
+# arch specific flags to pass to the gcc build
+# your crosscompiler should be configured equivalently
+# if not provided, will be derived from the compiler config
+#export GCC_ARCH_CONFIG_FLAGS="--with-float=soft --with-fpu=vfp"
+
+export ARCH=$A
 
 ## set the compiler environment
 export CC=gcc
@@ -21,20 +27,6 @@ export MAKE_THREADS=1
 # root perms to build.
 # if SUPER is set, the enter-chroot script will use super_chroot.
 #export SUPER=1
-
-#    ARM SPECIFIC STUFF    #
-
-## set your ARM floating point emulation [softfp/hard]
-## these flags are required to build the right toolchain
-## currently only softfp is supported by the stage0 compiler 
-## (hardfp is only marginally faster anyway)
-export ARM_FLOAT_MODE=softfp
-#export ARM_FLOAT_MODE=hard
-
-# set your ARM fpu type [vfp/neon/?]
-## currently only vfp is supported
-export ARM_FPU=vfp
-#export ARM_FPU=neon
 
 # you can use a prebuilt butch to speed the build up a bit
 # or in case you use aboriginal, with its uclibc toolchain lacking the

--- a/KEEP/config.stage1
+++ b/KEEP/config.stage1
@@ -6,10 +6,10 @@ export LOGPATH=/src/logs
 #MAKE_THREADS is passed via -j to make and can lead to enormous speed gains
 #set this to the number of availables cores + 1, e.g. 3 for a dualcore
 export MAKE_THREADS=1
-#export this only if you build for ARM, and set the right arch number (4-7)
-#export ARM_ARCH=6
 export CC=gcc
 export HOSTCC=gcc
+
+export ARCH=$A
 
 # set this if you don't want to build the kernel, only the headers
 # if you don't need the kernel anyway, this can save lots of time

--- a/build-stage0
+++ b/build-stage0
@@ -63,7 +63,7 @@ if ! grep -q "stage0 " "$R"/var/lib/butch.db 2>/dev/null ; then
 
 	CONFIG="$H"/config BUTCHDB="$R"/var/lib/butch.db "$R"/bin/butch install stage0
 	
-	cp "$K"/config.stage1 "$R"/src/config
-	echo "export A=$A" >> "$R"/src/config
+	echo "export A=$A" > "$R"/src/config
+	cat "$K"/config.stage1 >> "$R"/src/config
 	[ -z "$MAKE_THREADS" ] || sed -i "s@MAKE_THREADS=1@MAKE_THREADS=$MAKE_THREADS@" "$R"/src/config
 fi

--- a/pkg/gcc3
+++ b/pkg/gcc3
@@ -47,9 +47,10 @@ archflags=
 # it is supposed to be in libgcc for some archs. should not be too hard to fix, but it yet has to be done
 # musl-0.9.2/src/malloc/malloc.c:120: undefined reference to `__floatsisf'
 
-[ "$A" = "arm" ] && archflags="--with-float=soft --with-fpu=vfp --disable-multilib"
+[ "$A" = "arm" ] && archflags="--disable-multilib"
 [ "$A" = "x86_64" ] && archflags=--disable-multilib
 [ "$A" = "i386" ] && archflags=--disable-multilib
+[ -n "$GCC_ARCH_CONFIG_FLAGS" ] && archflags="$archflags $GCC_ARCH_CONFIG_FLAGS"
 
 # workaround for debian idiocy: they put bits/ into an arch-specific
 # sysdir in /usr/include, so the bootstrap compiler (xgcc), which

--- a/pkg/kernel
+++ b/pkg/kernel
@@ -15,6 +15,27 @@ cd linux-"$LINUX_VER"
 
 # get into menuconfig using
 # make HOSTCFLAGS="-D_GNU_SOURCE" HOSTLDFLAGS=-lncurses menuconfig
+gcc_confflag() {
+  local opt="${1:-}"
+  shift
+  local flags="${*:-}"
+  [ -z "$opt" ] && return 1
+  [ "$flags" = "auto" ] && \
+    flags="$($CC -v 2>&1 |egrep '^Configured with:')"
+  for w in $flags; do
+    case "$w" in
+      #we do not care about the -a part of armv7-a
+      "--${opt}="*) echo $w |sed -r 's,^.+=,,g; s,-.*,,g;';;
+      *);;
+    esac
+  done
+}
+if [ "$A" = arm ]; then
+  if [ -z "$ARM_ARCH" ]; then
+    ARM_ARCH="$(gcc_confflag with-arch $GCC_ARCH_CONFIG_FLAGS)"
+    ARM_ARCH="${arm_arch:-$(gcc_confflag with-arch auto)}"
+  fi
+fi
 
 dopatch() {
 	echo "applying patch $1"
@@ -52,8 +73,10 @@ if [ -z "$HOSTCC" ] ; then
 fi
 
 if [ "$A" = arm ] ; then
-	[ -z "$ARM_ARCH" ] && (echo "error: need to set ARM_ARCH to 4-7" ; exit 1)
-	linux_config="$linux_config $K/linux.config.armv${ARM_ARCH}l"
+	[ -z "$ARM_ARCH" ] && (echo "error: need to set ARM_ARCH to armv4-7"; exit 1)
+	[ -e "$K"/linux.config."${ARM_ARCH}"l ] || \
+	  (echo "error: no kernel configuration found $K/linux.config.$ARM_ARCH"; exit 1)
+	linux_config="$K/linux.config.${ARM_ARCH}l"
 fi
 
 cat "$linux_config" > my.config
@@ -95,7 +118,7 @@ if egrep -q '\=m$' my.config; then
   else
     v="$LINUX_VER"
   fi
-  depmod "$v"
+  depmod -b "$butch_root_dir" "$v"
 fi
 
 exit 0


### PR DESCRIPTION
now architecture-specific configure flags can be given, or will be autodetected