### PR TITLE
Hiawatha Webserver (and mbed TLS, aka polarssl)

### DIFF
--- a/KEEP/services/hiawatha
+++ b/KEEP/services/hiawatha
@@ -1,13 +1,19 @@
 #!/bin/sh
 
+SRVDIR=/var/www
+
 if ! grep -q '^www-data:' /etc/passwd ; then
 	busybox addgroup -S www-data
 	busybox adduser -h "$SRVDIR" -s /bin/nologin -S -D -H -G www-data www-data
-	if [ ! -d "$SRVDIR" ] ; then
-		install -D -d -m 755 "$SRVDIR"
-		chown -R www-data "$SRVDIR"
-		chgrp -R www-data "$SRVDIR"
-	fi
 fi
+
+if [ ! -d "$SRVDIR" ] ; then
+	install -D -d -m 755 "$SRVDIR"
+	chown -R www-data "$SRVDIR"
+	chgrp -R www-data "$SRVDIR"
+fi
+
+
+[ "$1" = "--prereqs" ] && exit 0
 
 hiawatha -d

--- a/KEEP/services/hiawatha
+++ b/KEEP/services/hiawatha
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+if ! grep -q '^www-data:' /etc/passwd ; then
+	busybox addgroup -S www-data
+	busybox adduser -h "$SRVDIR" -s /bin/nologin -S -D -H -G www-data www-data
+	if [ ! -d "$SRVDIR" ] ; then
+		install -D -d -m 755 "$SRVDIR"
+		chown -R www-data "$SRVDIR"
+		chgrp -R www-data "$SRVDIR"
+	fi
+fi
+
+hiawatha -d

--- a/pkg/hiawatha
+++ b/pkg/hiawatha
@@ -5,13 +5,15 @@ https://www.hiawatha-webserver.org/files/hiawatha-9.14.tar.gz
 filesize=891930
 sha512=66ad77c132d34daa5eb597ce67d7b26581c59534e5cf83dd65f78567a9a1798030cd42fef2d612bd1935243db979a2ef1df873f01b0d0a009395ef3da1dca6e6
 
+[deps.host]
+cmake
 
 [deps]
 mbedtls
-cmake
+
 
 [build]
-# NOTE: the mirror is requires tls, download with curl:
+# NOTE: the mirror requires tls, download with curl:
 #       USE_CURL=1 butch install hiawatha
 # NOTE: XSLT support requires libxlst
 # NOTE about mbedtls:
@@ -33,7 +35,7 @@ CFLAGS="-static" cmake \
 	-DCMAKE_INSTALL_MANDIR="$butch_prefix/share/man" \
 	-DCONFIG_DIR="$butch_prefix/etc/hiawatha" \
 	-DLOG_DIR="$butch_prefix/var/log/hiawatha" \
-	-DPID_DIR="$butch_prefix/etc/service/hiawatha/" \
+	-DPID_DIR="$butch_prefix/var/run/hiawatha" \
 	-DWEBROOT_DIR="$butch_prefix/var/www" \
 
 # hack that adds missing statically linked mbedtls libraries

--- a/pkg/hiawatha
+++ b/pkg/hiawatha
@@ -1,0 +1,51 @@
+[mirrors]
+https://www.hiawatha-webserver.org/files/hiawatha-9.14.tar.gz
+
+[main]
+filesize=891930
+sha512=66ad77c132d34daa5eb597ce67d7b26581c59534e5cf83dd65f78567a9a1798030cd42fef2d612bd1935243db979a2ef1df873f01b0d0a009395ef3da1dca6e6
+
+
+[deps]
+mbedtls
+cmake
+
+[build]
+# NOTE: the mirror is requires tls, download with curl:
+#       USE_CURL=1 butch install hiawatha
+# NOTE: XSLT support requires libxlst
+# NOTE about mbedtls:
+# Hiawatha usually compiles its own mbedtls to make sure it has the right
+# config options. In sabotage, we already have these options set, so we use
+# the system library of course.
+
+CFLAGS="-static" cmake \
+	-DENABLE_CACHE=OFF \
+	-DENABLE_RPROXY=OFF \
+	-DENABLE_TOOLKIT=OFF \
+	-DENABLE_XSLT=OFF \
+	-DUSE_SYSTEM_MBEDTLS=ON \
+	-DCMAKE_INSTALL_PREFIX="$butch_prefix" \
+	-DCMAKE_INSTALL_BINDIR="$butch_prefix/bin" \
+	-DCMAKE_INSTALL_SBINDIR="$butch_prefix/bin" \
+	-DCMAKE_INSTALL_SYSCONFDIR="$butch_prefix/etc/hiawatha" \
+	-DCMAKE_INSTALL_LIBDIR="$butch_prefix/lib" \
+	-DCMAKE_INSTALL_MANDIR="$butch_prefix/share/man" \
+	-DCONFIG_DIR="$butch_prefix/etc/hiawatha" \
+	-DLOG_DIR="$butch_prefix/var/log/hiawatha" \
+	-DPID_DIR="$butch_prefix/etc/service/hiawatha/" \
+	-DWEBROOT_DIR="$butch_prefix/var/www" \
+
+# add missing statically linked mbedtls libraries
+sed -i 's/-lmbedtls/-lmbedtls -lmbedcrypto -lmbedx509/' CMakeFiles/*/link.txt
+
+make V=1 -j$MAKE_THREADS
+
+# set the user-id to www-data (as in the service)
+sed -i 's/#ServerId = www-data/ServerId = www-data/' config/hiawatha.conf
+
+make DESTDIR="$butch_install_dir" install
+
+# install the service
+IS="$K"/bin/install-service
+"$IS" --down --log --force hiawatha "$K"/services/hiawatha

--- a/pkg/hiawatha
+++ b/pkg/hiawatha
@@ -15,9 +15,9 @@ cmake
 #       USE_CURL=1 butch install hiawatha
 # NOTE: XSLT support requires libxlst
 # NOTE about mbedtls:
-# Hiawatha usually compiles its own mbedtls to make sure it has the right
-# config options. In sabotage, we already have these options set, so we use
-# the system library of course.
+# Hiawatha usually compiles its own mbedtls to make sure it has the
+# right config options. In sabotage, we already have these options set,
+# so we use the system library of course.
 
 CFLAGS="-static" cmake \
 	-DENABLE_CACHE=OFF \
@@ -36,7 +36,8 @@ CFLAGS="-static" cmake \
 	-DPID_DIR="$butch_prefix/etc/service/hiawatha/" \
 	-DWEBROOT_DIR="$butch_prefix/var/www" \
 
-# add missing statically linked mbedtls libraries
+# hack that adds missing statically linked mbedtls libraries
+# thread: https://www.hiawatha-webserver.org/forum/topic/2010
 sed -i 's/-lmbedtls/-lmbedtls -lmbedcrypto -lmbedx509/' CMakeFiles/*/link.txt
 
 make V=1 -j$MAKE_THREADS

--- a/pkg/mbedtls
+++ b/pkg/mbedtls
@@ -10,6 +10,7 @@ sha512=184b7ad8a673db80321de9b63d6d1e19e1f62bea585efc6ac67e1c58ed312d112370dfd15
 
 [build]
 # FIXME: specify somewhere that the download requires curl (https only!)
+# Ticket for "make install" issues: https://github.com/ARMmbed/mbedtls/issues/232
 
 # cd from butch doesn't work because of the archive name
 cd /src/build/mbedtls/mbedtls-2.0.0/

--- a/pkg/mbedtls
+++ b/pkg/mbedtls
@@ -9,28 +9,35 @@ sha512=184b7ad8a673db80321de9b63d6d1e19e1f62bea585efc6ac67e1c58ed312d112370dfd15
 [deps]
 
 [build]
-# FIXME: specify somewhere that the download requires curl (https only!)
+# NOTE: the mirror requires tls, use curl.
 # Ticket for "make install" issues: https://github.com/ARMmbed/mbedtls/issues/232
 
 # cd from butch doesn't work because of the archive name
 cd /src/build/mbedtls/mbedtls-2.0.0/
 
+# hiawatha requires these options (USE_SYSTEM_MBEDTLS in its CMakeLists.txt)
+echo "#define MBEDTLS_THREADING_C" >> include/mbedtls/config.h
+echo "#define MBEDTLS_THREADING_PTHREAD" >> include/mbedtls/config.h
 
 # build the library and all binaries statically (includes mbedtls_selftest)
 make V=1 -j$MAKE_THREADS no_test
 
 
 # make install fix #1:
-# without this, testcases get built on "make install" (and they require
-# perl!)
+# when running make install, it builds the test cases (which require perl!)
 echo 'stub:' > tests/Makefile
 echo '	$(info skipping tests...)' >> tests/Makefile
 
 
 # make install fix #2:
-# without this, the Makefile generates symbolic link loops for all
-# binaries (because in line 36 $$o is always empty?)
+# it creates symbolic link loops for all binaries
+# (because in line 36 $$o is always empty?)
 sed -i '/ln -sf $$f/d' Makefile
 
 
 make DESTDIR="$butch_install_dir" install
+
+# make install fix #3:
+# it only copies libmbedtls.a, but not libmbedcrypto.a and libmbedx509.a
+cp library/libmbedx509.a "$butch_install_dir/lib"
+cp library/libmbedcrypto.a "$butch_install_dir/lib"

--- a/pkg/mbedtls
+++ b/pkg/mbedtls
@@ -1,0 +1,35 @@
+[mirrors]
+https://tls.mbed.org/download/mbedtls-2.0.0-gpl.tgz
+
+[main]
+filesize=1790002
+sha512=184b7ad8a673db80321de9b63d6d1e19e1f62bea585efc6ac67e1c58ed312d112370dfd157ed1ff2db76f2ff5dc2bc7e9808e4c6779707f2b2c426726c2e1f1c
+
+
+[deps]
+
+[build]
+# FIXME: specify somewhere that the download requires curl (https only!)
+
+# cd from butch doesn't work because of the archive name
+cd /src/build/mbedtls/mbedtls-2.0.0/
+
+
+# build the library and all binaries (includes mbedtls_selftest)
+make CFLAGS='--static' V=1 -j$MAKE_THREADS no_test
+
+
+# make install fix #1:
+# without this, testcases get built on "make install" (and they require
+# perl!)
+echo 'stub:' > tests/Makefile
+echo '	$(info skipping tests...)' >> tests/Makefile
+
+
+# make install fix #2:
+# without this, the Makefile generates symbolic link loops for all
+# binaries (because in line 36 $$o is always empty?)
+sed -i '/ln -sf $$f/d' Makefile
+
+
+make DESTDIR="$butch_install_dir" install

--- a/pkg/mbedtls
+++ b/pkg/mbedtls
@@ -9,29 +9,33 @@ sha512=184b7ad8a673db80321de9b63d6d1e19e1f62bea585efc6ac67e1c58ed312d112370dfd15
 [deps]
 
 [build]
-# NOTE: the mirror requires tls, use curl.
-# Ticket for "make install" issues: https://github.com/ARMmbed/mbedtls/issues/232
+# NOTE: the mirror is requires tls, download with curl:
+#       USE_CURL=1 butch install mbedtls
+# Ticket for "make install" issues (all fixed in the upcoming release):
+# https://github.com/ARMmbed/mbedtls/issues/232
 
 # cd from butch doesn't work because of the archive name
 cd /src/build/mbedtls/mbedtls-2.0.0/
 
-# hiawatha requires these options (USE_SYSTEM_MBEDTLS in its CMakeLists.txt)
+# hiawatha requires these options (USE_SYSTEM_MBEDTLS in its
+# CMakeLists.txt)
 echo "#define MBEDTLS_THREADING_C" >> include/mbedtls/config.h
 echo "#define MBEDTLS_THREADING_PTHREAD" >> include/mbedtls/config.h
 
-# build the library and all binaries statically (includes mbedtls_selftest)
+# build the library and all binaries statically (includes
+# mbedtls_selftest)
 make V=1 -j$MAKE_THREADS no_test
 
 
 # make install fix #1:
-# when running make install, it builds the test cases (which require perl!)
+# when running make install, it builds the test cases (which require
+# perl!)
 echo 'stub:' > tests/Makefile
 echo '	$(info skipping tests...)' >> tests/Makefile
 
 
 # make install fix #2:
 # it creates symbolic link loops for all binaries
-# (because in line 36 $$o is always empty?)
 sed -i '/ln -sf $$f/d' Makefile
 
 

--- a/pkg/mbedtls
+++ b/pkg/mbedtls
@@ -16,8 +16,8 @@ sha512=184b7ad8a673db80321de9b63d6d1e19e1f62bea585efc6ac67e1c58ed312d112370dfd15
 cd /src/build/mbedtls/mbedtls-2.0.0/
 
 
-# build the library and all binaries (includes mbedtls_selftest)
-make CFLAGS='--static' V=1 -j$MAKE_THREADS no_test
+# build the library and all binaries statically (includes mbedtls_selftest)
+make V=1 -j$MAKE_THREADS no_test
 
 
 # make install fix #1:

--- a/pkg/mbedtls
+++ b/pkg/mbedtls
@@ -2,22 +2,19 @@
 https://tls.mbed.org/download/mbedtls-2.0.0-gpl.tgz
 
 [main]
+tardir=mbedtls-2.0.0
 filesize=1790002
 sha512=184b7ad8a673db80321de9b63d6d1e19e1f62bea585efc6ac67e1c58ed312d112370dfd157ed1ff2db76f2ff5dc2bc7e9808e4c6779707f2b2c426726c2e1f1c
-
 
 [deps]
 
 [build]
-# NOTE: the mirror is requires tls, download with curl:
+# NOTE: the mirror requires tls, download with curl:
 #       USE_CURL=1 butch install mbedtls
 # Ticket for "make install" issues (all fixed in the upcoming release):
 # https://github.com/ARMmbed/mbedtls/issues/232
 
-# cd from butch doesn't work because of the archive name
-cd /src/build/mbedtls/mbedtls-2.0.0/
-
-# hiawatha requires these options (USE_SYSTEM_MBEDTLS in its
+# hiawatha requires these options (see USE_SYSTEM_MBEDTLS in its
 # CMakeLists.txt)
 echo "#define MBEDTLS_THREADING_C" >> include/mbedtls/config.h
 echo "#define MBEDTLS_THREADING_PTHREAD" >> include/mbedtls/config.h


### PR DESCRIPTION
The only thing that doesn't work is stopping the service with `sv stop hiawatha`, can someone help me with that (is it because of the PID path?) ?
Service file is based on the one by h2o - it also creates the www-data user if it doesn't exist.

Other than that, the server runs fine and is fully statically compiled.