### PR TITLE
redis port

### DIFF
--- a/KEEP/redis-sane-defaults.patch
+++ b/KEEP/redis-sane-defaults.patch
@@ -1,0 +1,31 @@
+diff --git a/redis.conf b/redis.conf
+index 6efb6ac..344e021 100644
+--- a/redis.conf
++++ b/redis.conf
+@@ -61,7 +61,7 @@ tcp-backlog 511
+ # Examples:
+ #
+ # bind 192.168.1.100 10.0.0.1
+-# bind 127.0.0.1
++bind 127.0.0.1
+ 
+ # Specify the path for the Unix socket that will be used to listen for
+ # incoming connections. There is no default, so Redis will not listen
+@@ -87,7 +87,7 @@ timeout 0
+ # On other kernels the period depends on the kernel configuration.
+ #
+ # A reasonable value for this option is 60 seconds.
+-tcp-keepalive 0
++tcp-keepalive 60
+ 
+ # Specify the server verbosity level.
+ # This can be one of:
+@@ -184,7 +184,7 @@ dbfilename dump.rdb
+ # The Append Only File will also be created inside this directory.
+ # 
+ # Note that you must specify a directory here, not a file name.
+-dir ./
++dir /var/lib/redis/
+ 
+ ################################# REPLICATION #################################
+ 

--- a/KEEP/services/redis
+++ b/KEEP/services/redis
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+DBDIR=/var/lib/redis
+
+if ! grep -q '^redis:' /etc/passwd ; then
+        busybox addgroup -S redis
+        busybox adduser -h "$DBDIR" -s /bin/nologin -S -D -H -G redis redis
+	chown redis:redis /etc/redis.conf
+fi
+
+if [ ! -d "$DBDIR" ] ; then
+        install -D -d -m 755 "$DBDIR"
+        chown -R redis "$DBDIR"
+        chgrp -R redis "$DBDIR"
+fi
+
+
+
+[ "$1" = "--prereqs" ] && exit 0
+
+
+# http://redis.io/topics/latency
+echo 'never' > /sys/kernel/mm/transparent_hugepage/enabled
+
+# see tcp-backlog in redis.conf
+echo 511 > /proc/sys/net/core/somaxconn
+
+su -s /bin/sh -c '/bin/redis-server /etc/redis.conf' - redis

--- a/KEEP/services/redis
+++ b/KEEP/services/redis
@@ -25,4 +25,4 @@ echo 'never' > /sys/kernel/mm/transparent_hugepage/enabled
 # see tcp-backlog in redis.conf
 echo 511 > /proc/sys/net/core/somaxconn
 
-su -s /bin/sh -c '/bin/redis-server /etc/redis.conf' - redis
+chpst -vP -u redis:redis -U redis:redis /bin/redis-server /etc/redis.conf

--- a/pkg/redis
+++ b/pkg/redis
@@ -1,0 +1,30 @@
+[mirrors]
+http://download.redis.io/releases/redis-3.0.3.tar.gz
+
+[main]
+filesize=1360959
+sha512=68b2d85341487efed26c92cd7925b4e9d889b5a19f08f4695ffd07087c01ae0c872086575744636513b01720829002c8d5c7bf43b20ee2c561599fa8d1c475f5
+
+
+[deps.host]
+
+[deps]
+su
+
+[build]
+# su is required in the service file, because redis can't drop rights on its own
+
+
+patch -p1 < "$K"/redis-sane-defaults.patch
+
+# MALLOC=libc: use musl malloc instead of jemalloc. This might be bad for performance though,
+# if that is important to you, you should make benchmarks (and share them)!
+make MALLOC=libc CFLAGS=-static V=1 -j$MAKE_THREADS
+
+make PREFIX="$butch_install_dir" install
+install -Dm400 redis.conf "$butch_install_dir"/etc/redis.conf
+
+
+# install the service
+IS="$K"/bin/install-service
+"$IS" --down --log --force redis "$K"/services/redis

--- a/pkg/redis
+++ b/pkg/redis
@@ -5,16 +5,12 @@ http://download.redis.io/releases/redis-3.0.3.tar.gz
 filesize=1360959
 sha512=68b2d85341487efed26c92cd7925b4e9d889b5a19f08f4695ffd07087c01ae0c872086575744636513b01720829002c8d5c7bf43b20ee2c561599fa8d1c475f5
 
-
-[deps.host]
-
 [deps]
-su
+
 
 [build]
-# su is required in the service file, because redis can't drop rights on its own
 
-
+# patch is from arch linux
 patch -p1 < "$K"/redis-sane-defaults.patch
 
 # MALLOC=libc: use musl malloc instead of jemalloc. This might be bad for performance though,


### PR DESCRIPTION
> [Redis](http://redis.io/) is an open source, BSD licensed, advanced key-value cache and store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets, sorted sets, bitmaps and hyperloglogs.

I need this for running a nodejs application. The redis.conf sane defaults patch (listen on localhost only, since it is without password!) is from [Arch Linux](https://projects.archlinux.org/svntogit/community.git/tree/trunk/redis.conf-sane-defaults.patch?h=packages/redis).

The service file is tested and works well :)