### PR TITLE
bump libressl to 2.2.4

### DIFF
--- a/pkg/libressl
+++ b/pkg/libressl
@@ -1,10 +1,10 @@
 [mirrors]
-http://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.2.3.tar.gz
-http://ftp.ch.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.2.3.tar.gz
+http://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.2.4.tar.gz
+http://ftp.ch.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.2.4.tar.gz
 
 [vars]
-filesize=2967547
-sha512=79f0cd57d2f1202e7d1213a9f9e0665bce11d1c1e5a4ba48c98b81f94e09a8c72733a5dfb0a5626b91db146641cfbec79acb9a5cbb437a60924b7f028d224500
+filesize=2966157
+sha512=390fbf4f531976c873a0a1163fd57f33097686c6956ec4d3eb69e8271a4e40abfec76d65172b34ae50af8936dd8b5c3ca5fefee9d8686ca468a5577d432c3fe5
 
 [deps]
 


### PR DESCRIPTION
fixes CVE-2015-5333 and CVE-2015-5334
http://www.openwall.com/lists/oss-security/2015/10/16/1