### PR TITLE
add node.js 4 (current LTS version)

### DIFF
--- a/pkg/nodejs
+++ b/pkg/nodejs
@@ -10,8 +10,10 @@ dynamic-toolchain
 python
 
 [build]
-# NOTE: node.js 0.12 is not maintained anymore upstream, but it is the
-# last version that builds with GCC 4.7.
+# nodejs has 3 supported versions currently:
+# - v5 (stable)
+# - v4 (LTS)
+# - v0.12 (Maintenance, does not require GCC 4.8, support end: 2017)
 
 patch -p1 < "$K"/nodejs-nameser_compat.h
 patch -p1 < "$K"/nodejs-openssl_termios.h

--- a/pkg/nodejs
+++ b/pkg/nodejs
@@ -17,7 +17,7 @@ patch -p1 < "$K"/nodejs-nameser_compat.h
 patch -p1 < "$K"/nodejs-openssl_termios.h
 patch -p1 < "$K"/nodejs-prefix.patch
 
-CFLAGS="-D_GNU_SOURCE" CXXFLAGS=-D_GNU_SOURCE ./configure --prefix="$butch_prefix"
+CFLAGS="-D_GNU_SOURCE -$optcflags" CXXFLAGS="-D_GNU_SOURCE $optcflags" LDFLAGS="$optldflags" ./configure --prefix="$butch_prefix"
 
 # the python configure script does not care about C(XX)FLAGS being passed
 sed -i "s@cflags': \[\]@cflags': ['-D_GNU_SOURCE -D_BSD_SOURCE']@" config.gypi

--- a/pkg/nodejs
+++ b/pkg/nodejs
@@ -17,7 +17,7 @@ patch -p1 < "$K"/nodejs-nameser_compat.h
 patch -p1 < "$K"/nodejs-openssl_termios.h
 patch -p1 < "$K"/nodejs-prefix.patch
 
-CFLAGS="-D_GNU_SOURCE -$optcflags" CXXFLAGS="-D_GNU_SOURCE $optcflags" LDFLAGS="$optldflags" ./configure --prefix="$butch_prefix"
+CFLAGS="-D_GNU_SOURCE $optcflags" CXXFLAGS="-D_GNU_SOURCE $optcflags" LDFLAGS="$optldflags" ./configure --prefix="$butch_prefix"
 
 # the python configure script does not care about C(XX)FLAGS being passed
 sed -i "s@cflags': \[\]@cflags': ['-D_GNU_SOURCE -D_BSD_SOURCE']@" config.gypi

--- a/pkg/nodejs
+++ b/pkg/nodejs
@@ -1,9 +1,10 @@
 [mirrors]
-http://nodejs.org/dist/v0.12.4/node-v0.12.4.tar.gz
+http://nodejs.org/dist/v0.12.9/node-v0.12.9.tar.gz
 
 [vars]
-filesize=19642076
-sha512=4d811a8f15068d2eea7e60a00c2803eb8ca8fd25b61ebf19aafc57be170abd75862d361ab9660e2be744efe66c69590b1a0a6b2bf8e3e72bb8d012c776262061
+filesize=19582666
+sha512=8b46864a1a2796fb45331dba21968676f491c3cfff2af31ec61a97dc78f2fa2f4143b1365d7218dbc471ea68407a55c65b9c7bbd0a73130284b38091639eedd2
+
 
 [deps.host]
 dynamic-toolchain

--- a/pkg/nodejs4
+++ b/pkg/nodejs4
@@ -1,21 +1,25 @@
 [mirrors]
-http://nodejs.org/dist/v0.12.4/node-v0.12.4.tar.gz
+http://nodejs.org/dist/v4.2.2/node-v4.2.2.tar.xz
 
 [vars]
-filesize=19642076
-sha512=4d811a8f15068d2eea7e60a00c2803eb8ca8fd25b61ebf19aafc57be170abd75862d361ab9660e2be744efe66c69590b1a0a6b2bf8e3e72bb8d012c776262061
+filesize=12791572
+sha512=fe6563ca641581afa4ba7fda1b25175eae474aeb196504cd82a6486bf9dfe6c753c554b31d9aa3b6453c509aa792615e897343de69a0b8bfd26759efaea2e1cb
 
 [deps.host]
 dynamic-toolchain
 python
 
 [build]
-# NOTE: node.js 0.12 is not maintained anymore upstream, but it is the
-# last version that builds with GCC 4.7.
+# Better fail here, than in the middle of the build!
+if ! (gcc --version | grep -q -E '((4\.[8-9])|([5-9]\.[0-9]+))\.'); then
+	echo "ERROR: GCC 4.8 or higher required!"
+	exit 1
+fi
 
 patch -p1 < "$K"/nodejs-nameser_compat.h
 patch -p1 < "$K"/nodejs-openssl_termios.h
 patch -p1 < "$K"/nodejs-prefix.patch
+
 
 CFLAGS="-D_GNU_SOURCE" CXXFLAGS=-D_GNU_SOURCE ./configure --prefix="$butch_prefix"
 

--- a/pkg/nodejs4
+++ b/pkg/nodejs4
@@ -1,9 +1,10 @@
 [mirrors]
-http://nodejs.org/dist/v4.2.2/node-v4.2.2.tar.xz
+http://nodejs.org/dist/v4.2.3/node-v4.2.3.tar.xz
 
 [vars]
-filesize=12791572
-sha512=fe6563ca641581afa4ba7fda1b25175eae474aeb196504cd82a6486bf9dfe6c753c554b31d9aa3b6453c509aa792615e897343de69a0b8bfd26759efaea2e1cb
+filesize=12768804
+sha512=4b6196ee7a430a7834d30424728ddeea7e0fa44d3776f53072931337a8396f8ea3620880f5962eec469f585723d9036b1a1768f859b080f973c5568fc0c060db
+
 
 [deps.host]
 dynamic-toolchain

--- a/pkg/nodejs4
+++ b/pkg/nodejs4
@@ -21,7 +21,7 @@ patch -p1 < "$K"/nodejs-openssl_termios.h
 patch -p1 < "$K"/nodejs-prefix.patch
 
 
-CFLAGS="-D_GNU_SOURCE -$optcflags" CXXFLAGS="-D_GNU_SOURCE $optcflags" LDFLAGS="$optldflags" ./configure --prefix="$butch_prefix"
+CFLAGS="-D_GNU_SOURCE $optcflags" CXXFLAGS="-D_GNU_SOURCE $optcflags" LDFLAGS="$optldflags" ./configure --prefix="$butch_prefix"
 
 # the python configure script does not care about C(XX)FLAGS being passed
 sed -i "s@cflags': \[\]@cflags': ['-D_GNU_SOURCE -D_BSD_SOURCE']@" config.gypi

--- a/pkg/nodejs4
+++ b/pkg/nodejs4
@@ -11,7 +11,7 @@ python
 
 [build]
 # Better fail here, than in the middle of the build!
-if ! (gcc --version | grep -q -E '((4\.[8-9])|([5-9]\.[0-9]+))\.'); then
+if ! ($CC --version | grep -q -E '((4\.[8-9])|([5-9]\.[0-9]+))\.'); then
 	echo "ERROR: GCC 4.8 or higher required!"
 	exit 1
 fi
@@ -21,7 +21,7 @@ patch -p1 < "$K"/nodejs-openssl_termios.h
 patch -p1 < "$K"/nodejs-prefix.patch
 
 
-CFLAGS="-D_GNU_SOURCE" CXXFLAGS=-D_GNU_SOURCE ./configure --prefix="$butch_prefix"
+CFLAGS="-D_GNU_SOURCE -$optcflags" CXXFLAGS="-D_GNU_SOURCE $optcflags" LDFLAGS="$optldflags" ./configure --prefix="$butch_prefix"
 
 # the python configure script does not care about C(XX)FLAGS being passed
 sed -i "s@cflags': \[\]@cflags': ['-D_GNU_SOURCE -D_BSD_SOURCE']@" config.gypi


### PR DESCRIPTION
I've kept the other nodejs recipe, because v4.x and higher require a newer GCC
than 4.7, which gets built by default in sabotage.

Also I've added an extra check for the GCC version at the very start of the
build. Otherwise the configure script would only print a notice, and the build
fails somehwere in the middle without throwing an error related to the GCC version.

Built successfully with GCC 5.2.0 on my machine.