### PR TITLE
pkg/stage0_musl: fix typo

### DIFF
--- a/pkg/stage0_musl
+++ b/pkg/stage0_musl
@@ -11,7 +11,7 @@ stage0_gcc
 [build]
 # do not rebuild stage0 packages once we're past that stage
 test "$STAGE" = "0" || exit 0
-patch -p1 < "K"/musl-1.1.13-fputs.patch
+patch -p1 < "$K"/musl-1.1.13-fputs.patch
 CC=$R/bin/gcc ./configure --enable-gcc-wrapper \
   --prefix=$butch_prefix --syslibdir=$butch_prefix/lib
 


### PR DESCRIPTION
./build-stage0 fails due to a missing "$" in pkg/stage0_musl.

This pull request fixes that little typo.
