### PR TITLE
rsync: add perl as dependency

### DIFF
--- a/pkg/rsync
+++ b/pkg/rsync
@@ -6,6 +6,7 @@ filesize=890124
 sha512=ec0e46ff532a09a711282aaa822f5f1c133593ee6c1c474acd67284619236e6a202f0f369d3e67a95ceb3a3b1c39ea7fb609d6d6fb950f3be6e0f6372e903e21
 
 [deps]
+perl
 
 [build]
 [ -n "$CROSS_COMPILE" ] && xconfflags="--host=$($CC -dumpmachine)"


### PR DESCRIPTION
rsync build fails with the following error if perl isn't available.

```
perl ./mkproto.pl ./*.c ./lib/compat.c
/bin/sh: perl: not found
make: *** [proto.h-tstamp] Error 127
```
