### PR TITLE
rsync: add patch to remove dependency on perl

### DIFF
--- a/KEEP/rsync-fix-proto.h-tstamp-target.patch
+++ b/KEEP/rsync-fix-proto.h-tstamp-target.patch
@@ -1,0 +1,12 @@
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -205,7 +205,7 @@
+ proto.h: proto.h-tstamp
+        @if test -f proto.h; then :; else cp -p $(srcdir)/proto.h .; fi
+ 
+-proto.h-tstamp: $(srcdir)/*.c $(srcdir)/lib/compat.c config.h
++proto.h-tstamp: $(srcdir)/*.c $(srcdir)/lib/compat.c
+        perl $(srcdir)/mkproto.pl $(srcdir)/*.c $(srcdir)/lib/compat.c
+ 
+ man: rsync.1 rsyncd.conf.5 man-copy
+

--- a/pkg/rsync
+++ b/pkg/rsync
@@ -8,6 +8,9 @@ sha512=ec0e46ff532a09a711282aaa822f5f1c133593ee6c1c474acd67284619236e6a202f0f369
 [deps]
 
 [build]
+# apply patch to remove dependency on perl
+# https://lists.samba.org/archive/rsync/2015-November/030439.html
+patch -p1 -l < "$K"/rsync-fix-proto.h-tstamp-target.patch
 [ -n "$CROSS_COMPILE" ] && xconfflags="--host=$($CC -dumpmachine)"
 CFLAGS="-D_GNU_SOURCE $optcflags" LDFLAGS="$optldflags" \
   ./configure -C --prefix="$butch_prefix" $xconfflags


### PR DESCRIPTION
rsync build fails with the following error if perl isn't available.

```
perl ./mkproto.pl ./*.c ./lib/compat.c
/bin/sh: perl: not found
make: *** [proto.h-tstamp] Error 127
```

Created a patch with the change noted here: https://lists.samba.org/archive/rsync/2015-November/030439.html
