### PR TITLE
bump libtorrent and rtorrent

### DIFF
--- a/pkg/libtorrent
+++ b/pkg/libtorrent
@@ -1,9 +1,9 @@
 [mirrors]
-http://pkgs.fedoraproject.org/repo/pkgs/libtorrent/libtorrent-0.13.4.tar.gz/e82f380a9d4b55b379e0e73339c73895/libtorrent-0.13.4.tar.gz
+http://rtorrent.net/downloads/libtorrent-0.13.6.tar.gz
 
 [vars]
-filesize=768382
-sha512=6a5ea944c1193d1160563828c5901f0cf557f38c4de61153d505344f3c3c8509c765e01b6cc5e3a53ec2bb184a9e8db32ed4ec154e93a93822804210f0fa45d0
+filesize=781253
+sha512=b8aea4060357a8a40d15d42f1f698ef6f3ebdc885000bfbfa5bf9c81af8c88b5503a107e05c214e3e8489126928d336356c5e7e0eaf836b6b84a3cf74633b050
 
 [deps.host]
 dynamic-toolchain
@@ -24,7 +24,7 @@ case "$A" in i[3-6]86) align=no ;; esac
 
 sed -i 's@-Wl,-syslibroot,@-Wl,-syslibroot=@' configure
 # remove execinfo.h test which breaks xcompile
-sed -i '18116,18150d' configure >/dev/null
+sed -i '18271,18305d' configure >/dev/null
 CPPFLAGS="-D_GNU_SOURCE" CFLAGS="$optcflags" CXXFLAGS="$optcflags" \
 LDFLAGS="$optldflags -Wl,-rpath-link=$butch_root_dir$butch_prefix/lib" \
 ./configure -C --prefix="$butch_prefix" $xconfflags \

--- a/pkg/rtorrent
+++ b/pkg/rtorrent
@@ -1,9 +1,9 @@
 [mirrors]
-http://pkgs.fedoraproject.org/repo/pkgs/rtorrent/rtorrent-0.9.4.tar.gz/fd9490a2ac67d0fa2a567c6267845876/rtorrent-0.9.4.tar.gz
+http://rtorrent.net/downloads/rtorrent-0.9.6.tar.gz
 
 [vars]
-filesize=601913
-sha512=ae243d0336acff50e91e4ed9d306beb4705559775518e6dc122ec18a1530e59e2c531cf54f4b79899a1569ca18d343fce255071b45c41df1357bddfe926692aa
+filesize=610845
+sha512=704f7b79d5bc78b817da21a6886662a5a97fde210a110c50f708bdc18e1dcf3ef5c5f4e2740261d41221cfc69c19926bf34e10057adf10601da9e6e06b2cef75
 desc='bittorrent p2p filesharing client'
 
 [deps]
@@ -16,7 +16,7 @@ curses
   --with-sysroot=$butch_root_dir"
 sed -i 's@-Wl,-syslibroot,@-Wl,-syslibroot=@' configure
 # remove broken execinfo.h check
-sed -i '15855,15890d' configure
+sed -i '15872,15906d' configure
 CPPFLAGS="-D_GNU_SOURCE" CFLAGS="$optcflags" CXXFLAGS="$optcflags" \
 LDFLAGS="$optldflags -Wl,-rpath-link=$butch_root_dir$butch_prefix/lib" \
 ./configure -C --prefix="$butch_prefix" $xconfflags


### PR DESCRIPTION
This pull request bumps both libtorrent and rtorrent to the latest version. I've changed the execinfo.h test removal according the new configure files.
