### PR TITLE
Adding b2sum: A sum utility for the BLAKE2 cryptohash function.

### DIFF
--- a/pkg/b2sum
+++ b/pkg/b2sum
@@ -1,0 +1,17 @@
+[mirrors]
+https://github.com/BLAKE2/BLAKE2/archive/648089e0555cbed6bd64fbc1e5b97568cde665d9.tar.gz
+
+[vars]
+filesize=502996
+sha512=c1990b15798ede4421731de66e46b38f8c8caffd46446a18b982a51baa6ee4097fba2ec9492e6e2915c26a5935120252523502941f2a8643f437a93c0b67fbf7
+tarname=blake2-648089e0555cbed6bd64fbc1e5b97568cde665d9.tar.gz
+tardir=BLAKE2-648089e0555cbed6bd64fbc1e5b97568cde665d9
+desc='A tool similar to the md5sum or shasum utilities but for BLAKE2.'
+
+[build]
+cd b2sum
+[ "$A" != "x86_64" ] && sed -i 's@-I../sse@@' makefile
+sed -i 's@ -fopenmp@@' makefile
+
+make
+PREFIX=/ make DESTDIR="$butch_install_dir" install


### PR DESCRIPTION
Tarball size: 68124710 (68.125MB)

$ time sha512sum otp_src_18.0.tar.gz
84ec2a3834270c1babe153572d6187faa36c12128e604037d55be01719788c0dd79d46769ea7090d530b746206a25fe02346b02849abee10ee41ed4ac7567c02  otp_src_18.0.tar.gz
0m0.32s real     0m0.00s user     0m0.00s system

$ time b2sum otp_src_18.0.tar.gz
fee70f49921c4fe3e38ae4f16b3491e51866ecf57a9e954c4bd5f0ec446604de3fa972fd1a8452acc73d6eaa3041ea2b738a694944af22da5b4352e8117dbfcf  otp_src_18.0.tar.gz
0m0.10s real     0m0.00s user     0m0.00s system

Time recorded on a Xeon E3-1240v3 with an Intel 530 Series SSD.

See https://blake2.net/ for further details.