### PR TITLE
busybox: make high ASCII chars printable

### DIFF
--- a/KEEP/busybox-libbb-make-unicode-printable.patch
+++ b/KEEP/busybox-libbb-make-unicode-printable.patch
@@ -1,0 +1,21 @@
+--- a/libbb/printable_string.c
++++ b/libbb/printable_string.c
+@@ -31,8 +31,6 @@ const char* FAST_FUNC printable_string(u
+ 		}
+ 		if (c < ' ')
+ 			break;
+-		if (c >= 0x7f)
+-			break;
+ 		s++;
+ 	}
+ 
+@@ -45,7 +43,7 @@ const char* FAST_FUNC printable_string(u
+ 			unsigned char c = *d;
+ 			if (c == '\0')
+ 				break;
+-			if (c < ' ' || c >= 0x7f)
++			if (c < ' ')
+ 				*d = '?';
+ 			d++;
+ 		}
+

--- a/pkg/busybox
+++ b/pkg/busybox
@@ -47,6 +47,7 @@ dopatch "$K"/busybox-ping.patch
 dopatch "$K"/busybox-ping2.patch
 dopatch "$K"/busybox-grep-x.patch
 dopatch "$K"/busybox-sort.patch
+dopatch "$K"/busybox-libbb-make-unicode-printable.patch
 
 
 #__inline seems to get activated when -std=gnu99 is used, causing havoc


### PR DESCRIPTION
Currently busybox utils like "ls" fail to display filenames containing UTF-8
characters, replacing any special characters with "?".
Change libbb's printable_string() function to allow high ASCII characters so
that unicode filenames are displayed correctls.

Taken from the OpenWrt.