### PR TITLE
curl: bump to 7.48.0

### DIFF
--- a/KEEP/curl-libressl.patch
+++ b/KEEP/curl-libressl.patch
@@ -1,0 +1,26 @@
+commit 240cd84b494e0ffee8ad261c43b927d246cf6be1
+Author: Daniel Stenberg <daniel@haxx.se>
+Date:   Wed Mar 23 10:04:48 2016 +0100
+
+    openssl: fix ERR_remove_thread_state() for boringssl/libressl
+    
+    The removed arg is only done in OpenSSL
+    
+    Bug: https://twitter.com/xtraemeat/status/712564874098917376
+
+diff --git a/lib/vtls/openssl.c b/lib/vtls/openssl.c
+index cbf2d21..b7e4462 100644
+--- a/lib/vtls/openssl.c
++++ b/lib/vtls/openssl.c
+@@ -95,7 +95,9 @@
+ 
+ #if (OPENSSL_VERSION_NUMBER >= 0x10000000L)
+ #define HAVE_ERR_REMOVE_THREAD_STATE 1
+-#if (OPENSSL_VERSION_NUMBER >= 0x10100004L)
++#if (OPENSSL_VERSION_NUMBER >= 0x10100004L) && \
++  !defined(LIBRESSL_VERSION_NUMBER) && \
++  !defined(OPENSSL_IS_BORINGSSL)
+ /* OpenSSL 1.1.0-pre4 removed the argument! */
+ #define HAVE_ERR_REMOVE_THREAD_STATE_NOARG 1
+ #endif
+

--- a/pkg/curl
+++ b/pkg/curl
@@ -1,9 +1,9 @@
 [mirrors]
-http://curl.haxx.se/download/curl-7.44.0.tar.lzma
-
-[vars]
-filesize=2792083
-sha512=efca81affff6c172d13bd31e9937cf8c35c58ac3a485ad3224d9645749b60564ffec678345347fde2d4a08c8fa5c7dc8d82cb7bb593a42ae71e803b9e2a85744
+https://curl.haxx.se/download/curl-7.48.0.tar.lzma
+                                                  
+[vars]                                            
+filesize=5924818
+sha512=1e4cc613aa56d3547beff46c3124a6cb3ba5df89da00055df0b27e2ad57beccec33fd80b2b0d0858cf0de45da5ab5cad8345b0f23f0c536a690a5eab7518a3af
 
 [deps]
 openssl
@@ -11,6 +11,8 @@ ca-certificates
 zlib
 
 [build]
+patch -p1 < "$K"/curl-libressl.patch
+
 [ -n "$CROSS_COMPILE" ] && \
   xconfflags="--host=$($CC -dumpmachine) --with-sysroot=$butch_root_dir"
 
@@ -25,5 +27,8 @@ LIBS="-lssl -lcrypto -lz" \
   --with-ca-path="$butch_prefix"/etc/ssl/certs \
   --with-random=/dev/urandom $xconfflags
 
+sed -i -e '/SUBDIRS/s:scripts::' Makefile
+
 make -j$MAKE_THREADS
 make DESTDIR="$butch_install_dir" install
+


### PR DESCRIPTION
- add patch to fix libressl compatibility
- disable building of "scripts" because this would add perl as a
  host dependency