### PR TITLE
su: install to $butch_install_dir instead of /bin

### DIFF
--- a/pkg/su
+++ b/pkg/su
@@ -3,4 +3,6 @@ $CC -std=gnu99 -fstack-protector-all -Wa,--noexecstack -s -Os -o su "$K"/su.c -s
 
 chmod 4755 su
 
-mv su "$butch_root_dir""$butch_prefix"/bin
+dest="$butch_install_dir""$butch_prefix"
+mkdir -p "$dest"/bin
+mv su "$dest"/bin


### PR DESCRIPTION
The su binary will be moved to $butch_install_dir$butch_prefix/bin/su
and symlinked from there, instead of directly moved to /bin/su.