### PR TITLE
libtorrent: disable debug information

### DIFF
--- a/pkg/libtorrent
+++ b/pkg/libtorrent
@@ -31,6 +31,7 @@ LDFLAGS="$optldflags -Wl,-rpath-link=$butch_root_dir$butch_prefix/lib" \
 ./configure -C --prefix="$butch_prefix" $xconfflags \
   --enable-aligned=$align --without-kqueue \
   --with-zlib="$butch_root_dir$butch_prefix" \
+  --disable-debug \
   --disable-instrumentation
 make -j$MAKE_THREADS
 make DESTDIR="$butch_install_dir" install


### PR DESCRIPTION
This reduces the size from 15.3mb to 1.6mb.