### PR TITLE
stage1: fix stage0 cleanup

### DIFF
--- a/pkg/stage1
+++ b/pkg/stage1
@@ -17,10 +17,9 @@ binutils
 patch
 
 [build]
-if [ -d "$butch_root_dir""$butch_staging_dir"/stage0 ] ; then
+if [ -d "$butch_root_dir""$butch_staging_dir"/stage0-musl ] ; then
 	rm -rf "$butch_root_dir""$butch_staging_dir"/gcc3
 	rm -rf "$butch_root_dir""$butch_staging_dir"/stage0-musl
-	rm -rf "$butch_root_dir""$butch_staging_dir"/stage0
 
 	butch unlink gcc3
 	butch relink $(ls -d "$butch_root_dir""$butch_staging_dir"/gcc4* |awk -F/ '{print $NF}' |tail -n1)


### PR DESCRIPTION
gcc3 and stage0-musl should get removed by installing stage1.
the cleanup never happens, because there is no stage0 directory.

this commit rewrites the check from stage0 to stage0-musl.