### PR TITLE
add initramfs:

### DIFF
--- a/KEEP/initramfs.sh
+++ b/KEEP/initramfs.sh
@@ -1,0 +1,66 @@
+#!/bin/busybox sh
+
+rescue() {
+	# Silence the kernel
+	echo 0 > /proc/sys/kernel/printk
+	echo "$@"
+	PS1="(initramfs) \w\$ " exec /bin/sh
+}
+
+export PATH=/bin
+/bin/busybox --install -s /bin
+
+# Setup "those" directories
+mkdir -p /proc /sys /dev
+mount -t proc proc /proc
+mount -t sysfs sysfs /sys
+mount -t devtmpfs devtmpfs /dev
+
+# Set default values
+init=/bin/init root=/dev/sda1
+
+# Import kernel options as local variables
+eval `cat /proc/cmdline|tr ' ' '\n'|grep '='`
+eval `cat /proc/cmdline|tr ' ' '\n'|grep -v '='|sed 's/.$/&=1/'`
+
+# Mount boot partition (required for CD boot)
+if [ -n "${boot}" ]; then
+	mkdir /boot
+	mount "${boot}" /boot
+fi
+
+# Try to mount the cryptdevice
+if [ -n "${crypt}" ]; then
+	# Silence the kernel
+	echo 0 > /proc/sys/kernel/printk
+	cryptdev=$(printf "%s\n" "$crypt" | cut -d: -f1)
+	mapper=$(printf "%s\n" "$crypt" | cut -d: -f2)
+	cryptsetup luksOpen "`findfs $cryptdev`" "$mapper" \
+		|| rescue "cryptsetup failed with code $?"
+fi
+
+# Scan around for lvm devices, see if you can find any
+if [ -n "${lvm}" ]; then
+	lvm vgscan
+	lvm vgchange -a y
+fi
+
+# Mount the rootfs with options
+mopts=""
+[ -n "${rw}" ]         && rootflags="${rootflags},rw"
+[ -n "${ro}" ]         && rootflags="${rootflags},ro"
+[ -n "${rootflags}" ]  && mountopts="${mopts} -o ${rootflags}"
+[ -n "${rootfstype}" ] && mountopts="${mopts} -t ${rootfstype}"
+dev=$(findfs "${root}")
+mount $mopts "${dev}" /root || rescue "rootfs: mount failed with code $?"
+
+# Check for some misc. conditions
+[ -x "/root${init}" ] || rescue "${init} not found"
+[ -n "${rescue}" ] && rescue "Rescue shell requested by kernel options"
+
+# Attempt final switch_root
+umount /sys /proc
+[ -d /boot ] && umount /boot
+mount --move /dev /root/dev
+exec switch_root /root "${init}"
+rescue "switch_root failed with $?"

--- a/pkg/initramfs
+++ b/pkg/initramfs
@@ -1,0 +1,22 @@
+[vars]
+pkgver=1
+
+[deps]
+busybox
+lvm
+cryptsetup
+
+[build]
+mkdir -p ramfs
+cp $K/initramfs.sh ramfs/init
+chmod +x ramfs/init
+
+mkdir -p ramfs/bin
+for bin in cryptsetup busybox lvm; do
+	[ -f $butch_root_dir/bin/$bin ] && \
+		cp -L $butch_root_dir/bin/$bin ramfs/bin/$bin
+done
+
+( cd ramfs && find . | cpio -H newc -o > ../ramfs.cpio )
+cat ramfs.cpio | gzip > ramfs.igz
+install -Dm 644 ramfs.igz $butch_install_dir/boot/initrd.img


### PR DESCRIPTION
This adds an initrd-style pre-userspace to be included in the bootloader
configuration. This is useful when your rootfs requires user-space actions
before being available. Examples:
    - lvm logical volumes (lvm)
    - encrypted partitions (cryptsetup)
    - squashfs rootfs

Step-by-step instruction for usage:
    - Install lvm or cryptsetup (or both), depending on your disk structure
    - Rebuild the initramfs so the executables get included
    - The initramfs is placed as /boot/initrd.img. Add it to your extlinux
        boot configuration with "`INITRD initrd.img`"
    - Use the kernel options from below to your extlinux config like this:
        "`APPEND cryptsetup=/dev/sda2:cryptroot root=/dev/mapper/cryptroot`"

The kernel options as defined in bootparam(7) still apply. You are
encouraged to read that manpage first. The options root, rootfstype,
rootfsflags, rw, ro and init are not interpreted by the kernel when an
initramfs is used, so the initramfs is going to use them for
mounting the rootfs.

The following additional kernel options are interpreted by the initramfs:

    boot=<device>
        Mount a block device as temporary /boot. You only need this when
        you want to loop-mount an squashfs as rootfs.

    cryptsetup=<device>:<name>
        Run cryptsetup to decrypt the blockdevice <device> and make it
        available from /dev/mapper/<name>

    lvm
        Before attempting to mount the root, scan for lvm volumes and make
        them available at /dev/mapper/<vol-group>-<vol-name>

    rescue
        Instead of attempting to boot the mounted rootfs, drop an shell

For the options cryptsetup, boot and root, it is also allowed to use syntax
of the format "`UUID=<uuid>`" or "`LABEL=<disk label>`". To find those values
for your existing partition, you can use blkid(8)

Example config:
```

LABEL Sabotage
    KERNEL vmlinuz
    INITRD initrd.img
    APPEND crypt=UUID=a7a....29d:nyu-crypt lvm root=/dev/mapper/vg01-root
```