### PR TITLE
initramfs: add overlay and boot partition capabilities.

### DIFF
--- a/KEEP/initramfs.sh
+++ b/KEEP/initramfs.sh
@@ -31,8 +31,8 @@ mount -t devtmpfs devtmpfs /dev
 init=/bin/init root=/dev/sda1
 
 # Import kernel options as local variables
-eval `cat /proc/cmdline|tr ' ' '\n'|grep '='`
-eval `cat /proc/cmdline|tr ' ' '\n'|grep -v '='|sed 's/.$/&=1/'`
+eval `cat cmdline|grep -o -E '[^=" ]+(|=[^ "]*|=\S*"[^"]*"\S* )' \
+	|awk '/=/{print $0;next;}{print $0 "=default"}'`
 
 # Mount boot partition (required for CD boot)
 if [ -n "$boot" ]; then


### PR DESCRIPTION
Fix broken mount options management.
Improves findfs handling to allow special file systems like tmpfs.
This also adds the overlayfs functionality, which will only work on a kernel
with OVERLAY_FS enabled.

This initramfs was tested to work with booting sabotage from ISO.