### PR TITLE
Add /etc/os-release for generic distribution detection

### DIFF
--- a/KEEP/etc/os-release
+++ b/KEEP/etc/os-release
@@ -1,0 +1,4 @@
+NAME="sabotage"
+ID="sabotage"
+DISTRIB_ID="sabotage"
+PRETTY_NAME="Sabotage Linux"


### PR DESCRIPTION
This allows for OS detection. Currently sabotage linux offers none of the common mechanisms.

usecase: syslinux autoconfig on multiboot systems.