### PR TITLE
Initramfs

### DIFF
--- a/KEEP/initramfs.sh
+++ b/KEEP/initramfs.sh
@@ -1,6 +1,10 @@
 #!/bin/busybox sh
 
 rescue() {
+	# If panic parameter is set, just exit. This will
+	# exit PID 1 and cause a kernel panic
+	[ -n "$panic" ] && exit 1
+
 	# Silence the kernel
 	echo 0 > /proc/sys/kernel/printk
 	echo "$@"

--- a/pkg/initramfs
+++ b/pkg/initramfs
@@ -5,6 +5,7 @@ pkgver=2
 busybox
 lvm
 cryptsetup
+kbd
 
 [build]
 mkdir -p ramfs


### PR DESCRIPTION
Fix missing dependency: kbd

Introduce "panic" parameter. This will effectively prohibit the rescue shell and cause a kernel panic instead.