### PR TITLE
scrot: add debian's focused window patch

### DIFF
--- a/pkg/scrot
+++ b/pkg/scrot
@@ -10,8 +10,13 @@ http://fossies.org/unix/privat/scrot-0.8.tar.gz
 [deps]
 imlib2
 giblib
+scrot-debian-patches
 
 [build]
+tar xf "$C"/scrot_0.8-18.debian.tar.xz
+patch -p1 < debian/patches/04-focused.patch
+patch -p1 < debian/patches/05-addfocusedmanpage.patch
+
 [ -n "$CROSS_COMPILE" ] && \
   xconfflags="--host=$($CC -dumpmachine|sed 's/musl/gnu/') \
   --with-sysroot=$butch_root_dir"

--- a/pkg/scrot-debian-patches
+++ b/pkg/scrot-debian-patches
@@ -1,0 +1,6 @@
+[mirrors]
+http://archive.ubuntu.com/ubuntu/pool/universe/s/scrot/scrot_0.8-18.debian.tar.xz
+
+[vars]
+filesize=9164
+sha512=225a857c2586a0eaaa17e8f3dacdb01c395cefac99be80665c3a26be25b6cc9785a26f16de464829eb26e0e51d7d5420fe7ed79c1bbbd6931043d01a72d9d832


### PR DESCRIPTION
This adds debian's ```-u, --focused``` option to scrot, which allows it to capture the focused window.