### PR TITLE
go14: bump to go1.4.3 (fixes -Wshift-negative-value error)

### DIFF
--- a/pkg/go14
+++ b/pkg/go14
@@ -1,9 +1,9 @@
 [mirrors]
-https://storage.googleapis.com/golang/go1.4.2.src.tar.gz
+https://storage.googleapis.com/golang/go1.4.3.src.tar.gz
 
 [vars]
-filesize=10921896
-sha512=cda1a29d4418875dffaf3324004ddae8e1bbb573f7668e6e0c03d8b61284f4db7fca244c181f2859f8ccdd3db6391fb21e0d98a1a9fc15096c15883249d48a9c
+filesize=10875170
+sha512=12bade4bce9aa4b34e2b9495ae65a1fc6a2449b3a43bc4de85c8b87ba223c2f999b2f37c1e2fe1188d8521118b5e5357d27afb8b85c0b8ebb4503d4125d25273
 tardir=go
 
 [deps.host]


### PR DESCRIPTION
I tried installing go14 and the build failed due to ```-Wshift-negative-value```.

After a quick search, the suggested solution is to bump to go1.4.3 (https://github.com/golang/go/issues/17183) which fixed the issue for me.