### PR TITLE
add gperf dep to fontconfig and work around build error

### DIFF
--- a/pkg/fontconfig
+++ b/pkg/fontconfig
@@ -9,6 +9,7 @@ pkgver=2
 [deps]
 freetype
 expat
+gperf
 
 [deps.host]
 pkgconf

--- a/pkg/fontconfig
+++ b/pkg/fontconfig
@@ -18,6 +18,11 @@ pkgconf
 printf "all:\n\ttrue\n\ninstall:\n\ttrue\n\n" > test/Makefile.in
 [ -n "$CROSS_COMPILE" ] && \
   xconfflags="--host=$($CC -dumpmachine|sed 's/musl/gnu/') --with-sysroot=$butch_root_dir"
+
+# https://bugs.freedesktop.org/show_bug.cgi?id=101280
+rm src/fcobjshash.h
+rm src/fcobjshash.gperf
+
 CFLAGS="-D_GNU_SOURCE $optcflags" \
 LDFLAGS="$optldflags" \
   ./configure -C --prefix="$butch_prefix" $xconfflags \

--- a/pkg/fontconfig
+++ b/pkg/fontconfig
@@ -9,10 +9,10 @@ pkgver=2
 [deps]
 freetype
 expat
-gperf
 
 [deps.host]
 pkgconf
+gperf
 
 [build]
 printf "all:\n\ttrue\n\ninstall:\n\ttrue\n\n" > test/Makefile.in


### PR DESCRIPTION
seems like the newer version of fontconfig requires gperf

also added workaround for https://bugs.freedesktop.org/show_bug.cgi?id=101280