### PR TITLE
gcc474: fix compile error on newer gperf versions

### DIFF
--- a/KEEP/gcc-474-gperf.patch
+++ b/KEEP/gcc-474-gperf.patch
@@ -1,0 +1,28 @@
+diff --git a/gcc/cp/cfns.gperf b/gcc/cp/cfns.gperf
+index ef1ed08..ba0c487 100644
+--- a/gcc/cp/cfns.gperf
++++ b/gcc/cp/cfns.gperf
+@@ -22,6 +22,9 @@ __inline
+ static unsigned int hash (const char *, unsigned int);
+ #ifdef __GNUC__
+ __inline
++#ifdef __GNUC_STDC_INLINE__
++__attribute__ ((__gnu_inline__))
++#endif
+ #endif
+ const char * libc_name_p (const char *, unsigned int);
+ %}
+diff --git a/gcc/cp/cfns.h b/gcc/cp/cfns.h
+index 62cdfab..d90a230 100644
+--- a/gcc/cp/cfns.h
++++ b/gcc/cp/cfns.h
+@@ -54,6 +54,9 @@ static unsigned int hash (const char *, unsigned int);
+ #ifdef __GNUC__
+ __inline
+ #endif
++#ifdef __GNUC_STDC_INLINE__
++__attribute__ ((__gnu_inline__))
++#endif
+ const char * libc_name_p (const char *, unsigned int);
+ /* maximum key range = 391, duplicates = 0 */
+ 

--- a/pkg/gcc474
+++ b/pkg/gcc474
@@ -36,6 +36,7 @@ patch -p1 < "$K"/gcc473-arm-hwcap.patch
 patch -p1 < "$K"/gcc473-config-sub.patch
 patch -p1 < "$K"/gcc473-powerpc-libc-stack-end.patch
 patch -p1 < "$K"/gcc-474-universal-initializer-no-warning.patch
+patch -p1 < "$K"/gcc-474-gperf.patch
 patch -p1 < "$K"/gcc474-libssp_nonshared.patch
 patch -p1 < "$K"/gcc474-libgcc_fixver.patch
 patch -p1 < "$K"/gcc4-boehm-gc.patch


### PR DESCRIPTION
https://gcc.gnu.org/ml/gcc-patches/2015-08/msg00375.html

not sure how many people still use gcc474, but I happened to be messing around with java JNI bindings and had to fix this package to get gcj and javac