### PR TITLE
add wine-staging

### DIFF
--- a/KEEP/wine-staging-dlclose.patch
+++ b/KEEP/wine-staging-dlclose.patch
@@ -1,0 +1,162 @@
+From 1e52ad38ded52a9f8259b7a3435aa38b44f6cc11 Mon Sep 17 00:00:00 2001
+From: xhe <xw897002528@gmail.com>
+Date: Sat, 19 Nov 2016 14:36:54 +0800
+Subject: [PATCH] ntdll: Hacks for libc do not unload after dlclose
+
+---
+ configure.ac        |   6 ++
+ dlls/ntdll/loader.c | 185 ++++++++++++++++++++++++++++++++--------------------
+ 2 files changed, 119 insertions(+), 72 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 06ab763..cb4d45a 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1153,6 +1153,12 @@ then
+ 
+     dnl *** End of X11/Xlib.h check
+ 
++    dnl Check for the unload_after_dlclose libc
++    AC_RUN_IFELSE(
++	      [AC_LANG_PROGRAM([[#include <dlfcn.h>]], [[dlclose(dlopen("./conftest", 0)); return 0;]])],
++	      ac_save_CPPFLAGS="$ac_save_CPPFLAGS -DNO_UNLOAD_AFTER_DLCLOSE",
++	      [])
++
+     dnl Check for the presence of OpenGL
+     opengl_msg=""
+     if test "x$with_opengl" != "xno"
+diff --git a/dlls/ntdll/loader.c b/dlls/ntdll/loader.c
+index 518a99f..0364fc6 100644
+--- a/dlls/ntdll/loader.c
++++ b/dlls/ntdll/loader.c
+@@ -2781,53 +2781,6 @@ void WINAPI RtlExitUserProcess( DWORD status )
+     exit( status );
+ }
+ 
+-/******************************************************************
+- *		LdrShutdownThread (NTDLL.@)
+- *
+- */
+-void WINAPI LdrShutdownThread(void)
+-{
+-    PLIST_ENTRY mark, entry;
+-    PLDR_MODULE mod;
+-    UINT i;
+-    void **pointers;
+-
+-    TRACE("()\n");
+-
+-    /* don't do any detach calls if process is exiting */
+-    if (process_detaching) return;
+-
+-    RtlEnterCriticalSection( &loader_section );
+-
+-    mark = &NtCurrentTeb()->Peb->LdrData->InInitializationOrderModuleList;
+-    for (entry = mark->Blink; entry != mark; entry = entry->Blink)
+-    {
+-        mod = CONTAINING_RECORD(entry, LDR_MODULE, 
+-                                InInitializationOrderModuleList);
+-        if ( !(mod->Flags & LDR_PROCESS_ATTACHED) )
+-            continue;
+-        if ( mod->Flags & LDR_NO_DLL_CALLS )
+-            continue;
+-
+-        MODULE_InitDLL( CONTAINING_RECORD(mod, WINE_MODREF, ldr), 
+-                        DLL_THREAD_DETACH, NULL );
+-    }
+-
+-    RtlAcquirePebLock();
+-    RemoveEntryList( &NtCurrentTeb()->TlsLinks );
+-    RtlReleasePebLock();
+-
+-    if ((pointers = NtCurrentTeb()->ThreadLocalStoragePointer))
+-    {
+-        for (i = 0; i < tls_module_count; i++) RtlFreeHeap( GetProcessHeap(), 0, pointers[i] );
+-        RtlFreeHeap( GetProcessHeap(), 0, pointers );
+-    }
+-    RtlFreeHeap( GetProcessHeap(), 0, NtCurrentTeb()->FlsSlots );
+-    RtlFreeHeap( GetProcessHeap(), 0, NtCurrentTeb()->TlsExpansionSlots );
+-    RtlLeaveCriticalSection( &loader_section );
+-}
+-
+-
+ /***********************************************************************
+  *           free_modref
+  *
+@@ -2927,6 +2880,57 @@ static void MODULE_DecRefCount( WINE_MODREF *wm )
+ }
+ 
+ /******************************************************************
++ *		LdrShutdownThread (NTDLL.@)
++ *
++ */
++void WINAPI LdrShutdownThread(void)
++{
++    PLIST_ENTRY mark, entry;
++    PLDR_MODULE mod;
++    UINT i;
++    void **pointers;
++
++    TRACE("()\n");
++
++    /* don't do any detach calls if process is exiting */
++    if (process_detaching) return;
++
++    RtlEnterCriticalSection( &loader_section );
++
++#ifdef NO_UNLOAD_AFTER_DLCLOSE
++    MODULE_FlushModrefs();
++#endif
++
++    mark = &NtCurrentTeb()->Peb->LdrData->InInitializationOrderModuleList;
++    for (entry = mark->Blink; entry != mark; entry = entry->Blink)
++    {
++        mod = CONTAINING_RECORD(entry, LDR_MODULE, 
++                                InInitializationOrderModuleList);
++        if ( !(mod->Flags & LDR_PROCESS_ATTACHED) )
++            continue;
++        if ( mod->Flags & LDR_NO_DLL_CALLS )
++            continue;
++
++        MODULE_InitDLL( CONTAINING_RECORD(mod, WINE_MODREF, ldr), 
++                        DLL_THREAD_DETACH, NULL );
++    }
++
++    RtlAcquirePebLock();
++    RemoveEntryList( &NtCurrentTeb()->TlsLinks );
++    RtlReleasePebLock();
++
++    if ((pointers = NtCurrentTeb()->ThreadLocalStoragePointer))
++    {
++        for (i = 0; i < tls_module_count; i++) RtlFreeHeap( GetProcessHeap(), 0, pointers[i] );
++        RtlFreeHeap( GetProcessHeap(), 0, pointers );
++    }
++    RtlFreeHeap( GetProcessHeap(), 0, NtCurrentTeb()->FlsSlots );
++    RtlFreeHeap( GetProcessHeap(), 0, NtCurrentTeb()->TlsExpansionSlots );
++    RtlLeaveCriticalSection( &loader_section );
++}
++
++
++/******************************************************************
+  *		LdrUnloadDll (NTDLL.@)
+  *
+  *
+@@ -2945,6 +2949,7 @@ NTSTATUS WINAPI LdrUnloadDll( HMODULE hModule )
+     free_lib_count++;
+     if ((wm = get_modref( hModule )) != NULL)
+     {
++#ifndef NO_UNLOAD_AFTER_DLCLOSE
+         TRACE("(%s) - START\n", debugstr_w(wm->ldr.BaseDllName.Buffer));
+ 
+         /* Recursively decrement reference counts */
+@@ -2958,6 +2963,10 @@ NTSTATUS WINAPI LdrUnloadDll( HMODULE hModule )
+         }
+ 
+         TRACE("END\n");
++#else
++	TRACE("apply hacks on this platform\n");
++	MODULE_DecRefCount(wm);
++#endif
+     }
+     else
+         retv = STATUS_DLL_NOT_FOUND;

--- a/pkg/cabextract
+++ b/pkg/cabextract
@@ -1,0 +1,19 @@
+[mirrors]
+http://www.cabextract.org.uk/cabextract-1.6.tar.gz
+
+[vars]
+filesize=241731
+sha512=d1c71c0292e3d73d8edbff5f5230b3127c63028f5aba1d0cad968bc945202fb9c0773327affce3d28466068377f029c80735adbabe0929d29b2204dea73738f8
+pkgver=1
+
+[build]
+[ -n "$CROSS_COMPILE" ] && \
+  xconfflags="--host=$($CC -dumpmachine) \
+  --with-sysroot=$butch_root_dir"
+
+CPPFLAGS="-D_GNU_SOURCE" CFLAGS="$optcflags" CXXFLAGS="$optcflags" \
+LDFLAGS="$optldflags -Wl,-rpath-link=$butch_root_dir$butch_prefix/lib" \
+  ./configure -C --prefix="$butch_prefix" --disable-nls $xconfflags
+
+make V=1 -j$MAKE_THREADS
+make DESTDIR="$butch_install_dir" install

--- a/pkg/wine-staging
+++ b/pkg/wine-staging
@@ -90,7 +90,7 @@ cp -f "$K"/config.sub tools/
 
 if [ "$enable_staging" = 1 ]
 then
-    tar xf "$C"/v2.11.tar.gz
+    tar xf "$C"/wine-staging-2.11.tar.gz
     wine-staging-2.11/patches/patchinstall.sh DESTDIR=. --all
 fi
 

--- a/pkg/wine-staging
+++ b/pkg/wine-staging
@@ -1,0 +1,109 @@
+[mirrors]
+http://dl.winehq.org/wine/source/2.x/wine-2.11.tar.xz
+
+[vars]
+filesize=19251116
+sha512=691f329c47af5e51498287029988b8ca0777bfc3902ed80fd315004aba2337a938e79177e752efe86423c9b34544df3952b8c443bf43149356575fac75a779ac
+pkgver=4
+desc='windows API emulator to execute win32 binaries. requires x86 32bit TC'
+
+[deps.host]
+flex
+bison
+freetype
+bash
+autoconf
+
+[deps]
+openal
+alsa-lib
+curses
+libjpeg
+libpng
+libx11
+freetype
+kernel-headers
+mesalib
+glu
+wine-staging-patches
+
+[build]
+# NOTE: staging is enabled by default and requires bash and autoconf
+#       if you want, you can compile with enable_staging=0 and remove
+#       the deps
+
+enable_staging="${option_staging:-1}"
+
+case "$A" in
+  x86_64)
+	printf "warning: building wine 64 bit (not compatible to win32)\n"
+	configflags=--enable-win64
+  ;;
+  i[3-6]86)
+	configflags=
+  ;;
+  *)
+	printf "error: wine can only be compiled on x86 platforms\n"
+	exit 1
+  ;;
+esac
+
+patch -p1 < "$K"/wine-file_h.patch
+patch -p1 < "$K"/wine-iphlpapi.patch
+patch -p1 < "$K"/wine-staging-dlclose.patch
+
+cp -f "$K"/config.sub tools/
+
+[ -n "$CROSS_COMPILE" ] && {
+  PKGCSR_SAVE="$PKG_CONFIG_SYSROOT_DIR"
+  PKGCLD_SAVE="$PKG_CONFIG_LIBDIR"
+  unset PKG_CONFIG_SYSROOT_DIR
+  unset PKG_CONFIG_LIBDIR
+  bit64=
+  "$HOSTCC" -dM -E - </dev/null | grep __x86_64 >/dev/null && bit64=--enable-win64
+  mkdir host
+  cd host
+  CPPFLAGS="-DHAVE_LINK_H -DNETDB_INTERNAL=-1" \
+  CC="$HOSTCC" CFLAGS="-O0 -g0" LDFLAGS= \
+  ../configure --disable-win16 --disable-tests $bit64 \
+  --without-alsa --without-capi --without-cms --without-coreaudio --without-cups \
+  --without-curses --without-dbus --without-fontconfig \
+  --without-gettext --without-gphoto --without-glu --without-gnutls \
+  --without-gsm --without-gstreamer --without-hal --without-jpeg --without-ldap \
+  --without-mpg123 --without-openal --without-opencl --without-opengl --without-openssl \
+  --without-osmesa --without-oss --without-png --without-sane --without-tiff \
+  --without-v4l --without-xcomposite --without-xcursor --without-xinerama \
+  --without-xinput --without-xinput2 --without-xml --without-xrandr \
+  --without-xrender --without-xshape --without-xshm --without-xslt \
+  --without-xxf86vm
+  make CC="$HOSTCC" -j$MAKE_THREADS tools/Makefile __tooldeps__
+  make CC="$HOSTCC" -j$MAKE_THREADS -C tools
+
+  cd ..
+  export PKG_CONFIG_SYSROOT_DIR="$PKGCSR_SAVE"
+  export PKG_CONFIG_LIBDIR="$PKGCLD_SAVE"
+  export FREETYPE_CFLAGS=-I"$butch_root_dir""$butch_prefix"/include/freetype2
+
+  xconfflags="--host=$($CC -dumpmachine) \
+  --with-sysroot=$butch_root_dir --with-wine-tools=host"
+}
+
+if [ "$enable_staging" = 1 ]
+then
+    tar xf "$C"/v2.11.tar.gz
+    wine-staging-2.11/patches/patchinstall.sh DESTDIR=. --all
+fi
+
+sed -i 's@EXTRALIBS =.*$@EXTRALIBS =$(LDFLAGS) -lz@' dlls/cabinet/Makefile.in
+
+CPPFLAGS="-DHAVE_LINK_H -DNETDB_INTERNAL=-1 -DNO_UNLOAD_AFTER_DLCLOSE" \
+CFLAGS="$optcflags" CXXFLAGS="$optcflags" \
+LDFLAGS="$optldflags -L$butch_root_dir$butch_prefix/lib -Wl,-rpath-link=$butch_root_dir$butch_prefix/lib" \
+./configure -C $xconfflags \
+  --prefix="$butch_prefix" \
+  --disable-win16 $configflags --disable-tests \
+  --libdir="$butch_prefix"/lib --mandir="$butch_prefix"/share/man \
+
+make -j$MAKE_THREADS
+make DESTDIR="$butch_install_dir" install
+

--- a/pkg/wine-staging-patches
+++ b/pkg/wine-staging-patches
@@ -5,3 +5,4 @@ https://github.com/wine-compholio/wine-staging/archive/v2.11.tar.gz
 filesize=10083147
 sha512=e2d05ee88e1cc932c2890f1db867a9382f2c62a00ea7d63fc6bd7b3fab57ea2f0e4908313cbed08b92e48d5bc17753b0b78f6cdf2cb64e81aa5725fd86cbc695
 pkgver=1
+tarball=wine-staging-2.11.tar.gz

--- a/pkg/wine-staging-patches
+++ b/pkg/wine-staging-patches
@@ -1,0 +1,7 @@
+[mirrors]
+https://github.com/wine-compholio/wine-staging/archive/v2.11.tar.gz
+
+[vars]
+filesize=10083147
+sha512=e2d05ee88e1cc932c2890f1db867a9382f2c62a00ea7d63fc6bd7b3fab57ea2f0e4908313cbed08b92e48d5bc17753b0b78f6cdf2cb64e81aa5725fd86cbc695
+pkgver=1


### PR DESCRIPTION
this is latest stable wine (2.11) plus the staging patchset which enables support for cutting edge features required by modern software (mainly games).

the reason I made this into a separate package is that wine 1.8.x is a safer bet for software that doesn't benefit from latest wine. for example, latest wine has ~20ms higher sound latency which becomes a problem in rhythm games, so in that case I just use old wine.

also, the staging patchset depends on bash and autoconf, so it's nice to not have them pulled in when you just want to run simple programs.

I also added cabextract because it's commonly used to install m$ stuff into wine prefixes (winetricks uses it).

I have tested this with steam (installed with winetricks) and a opengl windows game, everything appears to be working fine.

wine-file_h.patch and wine-iphlpapi.patch are the same as wine 1.8.x because the affected files are compatible and unchanged.