### PR TITLE
Firefox wrapper script fixes

### DIFF
--- a/pkg/firefox
+++ b/pkg/firefox
@@ -240,7 +240,7 @@ cat << EOF > "$dest"/bin/firefox
 #!/bin/sh
 FFDIR="$dest/lib/firefox-${FF_VERSION}"
 LD_LIBRARY_PATH="\$FFDIR" \
-"\$FFDIR"/firefox-bin
+"\$FFDIR"/firefox-bin "\$@"
 EOF
 chmod +x "$dest"/bin/firefox
 

--- a/pkg/firefox
+++ b/pkg/firefox
@@ -240,7 +240,7 @@ cat << EOF > "$dest"/bin/firefox
 #!/bin/sh
 FFDIR="$dest/lib/firefox-${FF_VERSION}"
 LD_LIBRARY_PATH="\$FFDIR" \
-"\$FFIDR"/firefox-bin
+"\$FFDIR"/firefox-bin
 EOF
 chmod +x "$dest"/bin/firefox
 


### PR DESCRIPTION
there was a spelling mistake (FFIDR) that prevented the wrapper script from working

also, I've added command line args so you can call ```firefox https://...``` and it will work