### PR TITLE
wine-staging: bump to 2.13

### DIFF
--- a/pkg/wine-staging
+++ b/pkg/wine-staging
@@ -1,10 +1,10 @@
 [mirrors]
-http://dl.winehq.org/wine/source/2.x/wine-2.11.tar.xz
+http://dl.winehq.org/wine/source/2.x/wine-2.13.tar.xz
 
 [vars]
-filesize=19251116
-sha512=691f329c47af5e51498287029988b8ca0777bfc3902ed80fd315004aba2337a938e79177e752efe86423c9b34544df3952b8c443bf43149356575fac75a779ac
-pkgver=4
+filesize=19439328
+sha512=71873b9ec1605dd5f7502b87b0f3429c3d14a4196543d7304df455854b58ef82b8fafdcea91450cbfc01434a44886a0e0c4c4cf289ffb53167dde0f969cddc48
+pkgver=5
 desc='windows API emulator to execute win32 binaries. requires x86 32bit TC'
 
 [deps.host]
@@ -90,8 +90,8 @@ cp -f "$K"/config.sub tools/
 
 if [ "$enable_staging" = 1 ]
 then
-    tar xf "$C"/wine-staging-2.11.tar.gz
-    wine-staging-2.11/patches/patchinstall.sh DESTDIR=. --all
+    tar xf "$C"/wine-staging-2.13.tar.gz
+    wine-staging-2.13/patches/patchinstall.sh DESTDIR=. --all
 fi
 
 sed -i 's@EXTRALIBS =.*$@EXTRALIBS =$(LDFLAGS) -lz@' dlls/cabinet/Makefile.in

--- a/pkg/wine-staging-patches
+++ b/pkg/wine-staging-patches
@@ -1,8 +1,8 @@
 [mirrors]
-https://github.com/wine-compholio/wine-staging/archive/v2.11.tar.gz
+https://github.com/wine-compholio/wine-staging/archive/v2.13.tar.gz
 
 [vars]
-filesize=10083147
-sha512=e2d05ee88e1cc932c2890f1db867a9382f2c62a00ea7d63fc6bd7b3fab57ea2f0e4908313cbed08b92e48d5bc17753b0b78f6cdf2cb64e81aa5725fd86cbc695
-pkgver=1
-tarball=wine-staging-2.11.tar.gz
+filesize=10137549
+sha512=86077747d8a4f6e56dc1b0dda1688810defa9bcebaaadbf2419ce56e4590d4249881105e1dda24236f861baf0b1cc42019b2538de5d24a6d3c4f27c7a8248086
+pkgver=2
+tarball=wine-staging-2.13.tar.gz


### PR DESCRIPTION
the latest steam update broke steam on wine due to WSAIoctl returning invalid size for some value https://bugs.winehq.org/show_bug.cgi?id=43315

version 2.13 fixes this issue