### PR TITLE
add w3m pkg

### DIFF
--- a/KEEP/w3m-patch.patch
+++ b/KEEP/w3m-patch.patch
@@ -1,0 +1,23 @@
+--- w3m-0.5.3/main.c
++++ w3m-pathced/main.c
+@@ -833,7 +833,6 @@
+     mySignal(SIGPIPE, SigPipe);
+ #endif
+ 
+-    orig_GC_warn_proc = GC_set_warn_proc(wrap_GC_warn_proc);
+     err_msg = Strnew();
+     if (load_argc == 0) {
+ 	/* no URL specified */
+--- w3m-0.5.3/url.c
++++ w3m-pathced/url.c
+@@ -268,10 +268,6 @@
+     if (RAND_status())
+ 	return;
+     if ((file = RAND_file_name(buffer, sizeof(buffer)))) {
+-#ifdef USE_EGD
+-	if (RAND_egd(file) > 0)
+-	    return;
+-#endif
+ 	RAND_load_file(file, -1);
+     }
+     if (RAND_status())

--- a/pkg/w3m
+++ b/pkg/w3m
@@ -1,0 +1,27 @@
+[mirrors]
+http://downloads.sourceforge.net/project/w3m/w3m/w3m-0.5.3/w3m-0.5.3.tar.gz
+
+[vars]
+filesize=2202328
+sha512=43508c76d07b4d8f19c19f975c0b870aeb94abf0744b6128ee01c759d4e409a8b57bc866baeaf990f309ff73e9a7b02ca455d272b1dd0a93fafb8c72b1fe6d14
+pkgver=1
+
+[deps]
+libgc
+gdk-pixbuf
+
+[build]
+patch -p1 < "$K"/w3m-patch.patch
+
+[ -n "$CROSS_COMPILE" ] && \
+  xconfflags="--host=$($CC -dumpmachine) \
+  --with-sysroot=$butch_root_dir"
+
+
+CFLAGS="$optcflags" \
+LDFLAGS="$optldflags -Wl,-rpath-link=$butch_root_dir$butch_prefix/lib" \
+  ./configure --with-imagelib="gdk-pixbuf" --enable-image="x11,fb,fb+s" \
+  -C --prefix="$butch_prefix" --disable-nls $xconfflags
+
+make V=1 -j$MAKE_THREADS
+make DESTDIR="$butch_install_dir" install


### PR DESCRIPTION
[w3m](http://w3m.sourceforge.net/) - a terminal web browser much like links or lynx, however w3m can render images inside the terminal within a frame buffer. Useful for previewing images in terminal through apps like [ranger](https://github.com/ranger/ranger).

------------

**Note on gdk-pixbuf dep:** this can work with using imlib2 instead of pixbuf, but after a lot of work I couldn't get it to compile. With pixbuf, it compiled after only a few small patches. imlib2 would be *technically* better though if anyone wants to try and hack it