### PR TITLE
add mpd-mpc pkg

### DIFF
--- a/pkg/mpd-mpc
+++ b/pkg/mpd-mpc
@@ -1,0 +1,25 @@
+[mirrors]
+https://musicpd.org/download/mpc/0/mpc-0.28.tar.xz
+
+[vars]
+filesize=109172
+sha512=1d0c96c3c7cee2eac2d3cf25f09d74b5807b8ea56ff7dfc033b8fa690fd4d42de726a641e4f2552550d8a1c1b2840575aec5c595166ca5ae5776fcc93c8fb7cf
+pkgver=1
+
+[deps]
+libmpdclient
+
+[deps.run]
+mpd
+
+[build]
+[ -n "$CROSS_COMPILE" ] && \
+  xconfflags="--host=$($CC -dumpmachine) \
+  --with-sysroot=$butch_root_dir"
+
+CPPFLAGS="-D_GNU_SOURCE" CFLAGS="$optcflags" CXXFLAGS="$optcflags" \
+LDFLAGS="$optldflags -Wl,-rpath-link=$butch_root_dir$butch_prefix/lib" \
+  ./configure -C --prefix="$butch_prefix" --disable-nls $xconfflags
+
+make V=1 -j$MAKE_THREADS
+make DESTDIR="$butch_install_dir" install


### PR DESCRIPTION
small command line client to interface with mpd. Useful for making keybind shortcuts to skip songs or etc.

-----------

**NOTE**: requires mpd and libmpdclient, see other PRs