### PR TITLE
fixup mpd

### DIFF
--- a/pkg/mpd
+++ b/pkg/mpd
@@ -11,7 +11,7 @@ curl
 ffmpeg
 sqlite
 boost
-
+libvorbis
 
 [build]
 [ -n "$CROSS_COMPILE" ] && \
@@ -19,8 +19,9 @@ boost
   --with-sysroot=$butch_root_dir"
 
 CPPFLAGS="-D_GNU_SOURCE" CFLAGS="$optcflags" CXXFLAGS="$optcflags" \
-LDFLAGS="$optldflags -Wl,-rpath-link=$butch_root_dir$butch_prefix/lib" \
-  ./configure -C --prefix="$butch_prefix" --disable-nls $xconfflags
+LDFLAGS="-lterminfo $optldflags -Wl,-rpath-link=$butch_root_dir$butch_prefix/lib" \
+./configure --enable-vorbis --disable-ipv6 --enable-libmpdclient \
+--disable-systemd-daemon -C --prefix="$butch_prefix" --disable-nls $xconfflags
 
 make V=1 -j$MAKE_THREADS
 make DESTDIR="$butch_install_dir" install


### PR DESCRIPTION
was getting compiling errors that for some reason I wasn't getting before.

Adding "-lterminfo" to LDDFLAGS fixed the issue.

also added configure flags to be more inline with sabotage. (disable systemd, disable ipv6)