### PR TITLE
Fix gid_map for super_chroot

### DIFF
--- a/KEEP/super_chroot.c
+++ b/KEEP/super_chroot.c
@@ -26,11 +26,13 @@ int main(int argc, char **argv)
 	write(fd, buf, snprintf(buf, sizeof buf, "0 %u 1\n", uid));
 	close(fd);
 
+	fd = open("/proc/self/setgroups", O_RDWR);
+	write(fd, buf, snprintf(buf, sizeof buf, "deny\n"));
+	close(fd);
+
 	fd = open("/proc/self/gid_map", O_RDWR);
 	write(fd, buf, snprintf(buf, sizeof buf, "0 %u 1\n", gid));
 	close(fd);
-
-	setgroups(0, 0);
 
 	chdir(argv[1]);
 	chk(mount("/dev", "./dev", 0, MS_BIND|MS_REC, 0));


### PR DESCRIPTION
user_namespaces(7) states that the setgroups(2) syscall must be
explicitly disabled for an following write to the gid_map to succeed.

Before this commit, these writes failed silently with EPERM.