### PR TITLE
Remove /bin/sh from enter-chroot invocation

### DIFF
--- a/enter-chroot
+++ b/enter-chroot
@@ -61,7 +61,7 @@ set_title() {
 if [ -n "$1" ]; then
     $linux32 "$CHROOT" "$R" /bin/env -i \
         HOME=/root TERM="$TERM" PS1='\u:\w$ ' \
-        /bin/sh "$@"
+	"$@"
 	ret=$?
 else
     set_title "SABOTAGE CHROOT $(basename $R)"


### PR DESCRIPTION
This makes the invocation of enter-chroot be like that of regular chroot.