### PR TITLE
Updating and repurposing optimize-chroot.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,11 @@ At this point, stage1 is complete and your Sabotage chroot is set up. There are
 two optional steps to consider at this time:
 
 	$ /src/utils/clean-stage1.sh     # remove unneeded bootstrap packages
-	$ /src/utils/optimize-chroot.sh  # rebuild stage1 binaries with latest gcc
+	$ /src/utils/rebuild-stage1.sh   # rebuild core packages with the stage1 gcc
+
+Rebuilding stage1 will not only optimize the packages built with the older
+bootstrap compiler, but will also ensure that your builds are reproducible
+and will match the results of others.
 
 You may also install optional packages:
 

--- a/utils/optimize-chroot.sh
+++ b/utils/optimize-chroot.sh
@@ -2,6 +2,6 @@
 # use: optimize-chroot.sh [no args]
 # Rebuilds the stage0/1 binaries with the stage 1 compiler.
 
-butch rebuild jobflow patch busybox binutils make \
-	m4 gmp mpfr mpc libz libelf gcc630 \
-	musl 9base pkgconf libblkid e2fsprogs join libressl
+butch rebuild jobflow sabotage-core patch busybox binutils make \
+	kbd m4 gmp mpfr mpc libz libelf gcc640 musl 9base pkgconf \
+	libblkid e2fsprogs man join libressl ca-certificates

--- a/utils/rebuild-stage1.sh
+++ b/utils/rebuild-stage1.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# use: optimize-chroot.sh [no args]
+# use: rebuild-stage1.sh [no args]
 # Rebuilds the stage0/1 binaries with the stage 1 compiler.
 
 butch rebuild jobflow sabotage-core patch busybox binutils make \


### PR DESCRIPTION
After a conversation with @rofl0r, it appears that `optimize-chroot.sh` could be used as a more general step for reproducible builds. The script has also been renamed to be more generic about its purpose, as it is no longer just for optimization reasons.

The order of the packages mirror the order they are built during stage0 -> stage1. Everything that involves a C compiler in stage0/stage1 has now been included.

Added:
* sabotage-core
* kbd
* man
* ca-certificates

The necessity of all of these packages being rebuilt should probably be debated, but there's no harm including them either.