### PR TITLE
xkeyboard-config update

### DIFF
--- a/pkg/xkeyboard-config
+++ b/pkg/xkeyboard-config
@@ -1,10 +1,10 @@
 [mirrors]
-ftp://ftp.x.org/pub/individual/data/xkeyboard-config-1.4.tar.bz2
-http://ftp.x.org/pub/individual/data/xkeyboard-config-1.4.tar.bz2
+https://xorg.freedesktop.org/archive/individual/data/xkeyboard-config/xkeyboard-config-2.22.tar.bz2
 
 [vars]
-filesize=559151
-sha512=b7d3c6ede10a9f00c56328bd8e7fa01073031e29549f5d08a6a273670248a4ce6a58d994e5e234bf999080f0d7efd2d2ba970d176475dd5eb20a21ef01c6eab8
+filesize=1046333
+sha512=1697cc1a49625eb608d8ab1f54f9f37e37facc482fc8bae5ebff9e3336efdd2f57e0ed95db0a9745d49f1bc21e2cfa792d0849f4057745d8be8f7abac4893f97
+pkgver=1
 
 [deps]
 gettext
@@ -28,4 +28,8 @@ done
 
 make -j$MAKE_THREADS
 make DESTDIR="$butch_install_dir" install
+dest="$butch_install_dir""$butch_prefix"
+mkdir -p "$dest"/lib/pkgconfig
+mv "$dest"/share/pkgconfig/* "$dest"/lib/pkgconfig/
+rm -rf "$dest"/share/pkgconfig
 


### PR DESCRIPTION
Update fixes a bug I had when remapping backspace.
xorg still builds.
Here is the build log: 
[build_xkeyboard-config.log](https://github.com/sabotage-linux/sabotage/files/2236718/build_xkeyboard-config.log)
