### PR TITLE
gdb for aarch64

### DIFF
--- a/KEEP/gdb-76-aarch64-linux-nat.patch
+++ b/KEEP/gdb-76-aarch64-linux-nat.patch
@@ -1,0 +1,10 @@
+--- a/gdb/aarch64-linux-nat.c
++++ b/gdb/aarch64-linux-nat.c
+@@ -32,6 +32,7 @@
+ #include "elf/common.h"
+
+ #include <sys/ptrace.h>
++#include <asm/ptrace.h>
+ #include <sys/utsname.h>
+
+ #include "gregset.h"

--- a/pkg/gdb76
+++ b/pkg/gdb76
@@ -31,6 +31,7 @@ patch -p1 < "$K"/gdb-76-readline.patch
 patch -p1 < "$K"/gdb-76-pid_t.patch
 patch -p1 < "$K"/gdb-76-configure-ash.patch
 patch -p1 < "$K"/gdb-76-debuglink-dir.patch
+patch -p1 < "$K"/gdb-76-aarch64-linux-nat.patch
 
 # fix mips build ...
 cp "$K"/gdb-sgidefs.h gdb/sgidefs.h

--- a/pkg/gdb76
+++ b/pkg/gdb76
@@ -89,7 +89,7 @@ tuiflags=
 [ "$WANT_TUI" = 1 ] || tuiflags=--disable-tui
 
 xconfflags=
-targets="--enable-64-bit-bfd --enable-targets=x86_64-linux,i386-linux,powerpc-linux,arm-linux,mips-linux,mipsel-linux,microblaze-linux"
+targets="--enable-64-bit-bfd --enable-targets=x86_64-linux,i386-linux,powerpc-linux,arm-linux,mips-linux,mipsel-linux,microblaze-linux,aarch64-linux"
 if [ -n "$CROSS_COMPILE" ] ; then
 	xconfflags="--host=$($CC -dumpmachine)"
 	targets=


### PR DESCRIPTION
fixes cross and native compilation and adds aarch64 as a target to gdb