### PR TITLE
Aarch64

### DIFF
--- a/KEEP/pkg_skel/autoconf
+++ b/KEEP/pkg_skel/autoconf
@@ -10,6 +10,7 @@ pkgver=1
 [build]
 #patch -p1 < "$K"/some.patch
 #cp -f "$K"/config.sub .
+#xconfflags="--build=$($CC -dumpmachine)"
 [ -n "$CROSS_COMPILE" ] && \
   xconfflags="--host=$($CC -dumpmachine) \
   --with-sysroot=$butch_root_dir"

--- a/pkg/bison
+++ b/pkg/bison
@@ -13,7 +13,12 @@ m4
 
 [build]
 printf "all:\n\ttrue\n\ninstall:\n\ttrue\n\n" > tests/Makefile.in
-[ -n "$CROSS_COMPILE" ] && xconfflags="--host=$($CC -dumpmachine|sed 's/musl/gnu/')"
+cp -f "$K"/config.sub build-aux/
+
+xconfflags="--build=$($CC -dumpmachine)"
+[ -n "$CROSS_COMPILE" ] && \
+  xconfflags="--host=$($CC -dumpmachine)"
+
 CFLAGS="$optcflags" LDFLAGS="-static $optldflags" \
   ./configure -C --prefix="$butch_prefix" --disable-nls $xconfflags
 make -j$MAKE_THREADS

--- a/pkg/make
+++ b/pkg/make
@@ -20,6 +20,7 @@ patch -p1 < "$K"/make-3.82-stack_limit.patch
 patch -p1 < "$K"/make-glob.patch
 cp -f "$K"/config.sub config/
 
+xconfflags="--build=$($CC -dumpmachine)"
 [ -n "$CROSS_COMPILE" ] && \
   xconfflags="--host=$($CC -dumpmachine)"
 


### PR DESCRIPTION
hopefully clearer commit messages.
--build flag in configure skips config.guess so we can compile natively on aarch64.