### PR TITLE
changes to KEEP/bin/butch-core

### DIFF
--- a/KEEP/bin/butch-core
+++ b/KEEP/bin/butch-core
@@ -263,7 +263,7 @@ if test $mode = outdated || test $mode = update ; then
 	args=
 	for i in $($BINDIR/butch-list) ; do
 		test ! -e "$S"/pkg/"$i" && continue
-		if test $(get_pkgver "$i") != $(get_pkgver_installed "$i")
+		if test $(get_pkgver "$i") -gt $(get_pkgver_installed "$i")
 		then
 			add_list args "$i"
 		fi

--- a/KEEP/bin/butch-core
+++ b/KEEP/bin/butch-core
@@ -30,15 +30,15 @@ commands: install, rebuild, prefetch
 
 pass an arbitrary number of package names as options
 
-        install: installs one or more packages when they're not yet installed
-                (list of installed packages is kept in /var/lib/butch.db unless
-                 overridden via BUTCHDB env var.)
-        rebuild: installs one or more packages even when they're already
-                installed
-        prefetch: only download the given package and all of its dependencies,
-                unless they're not already in $C
-        update: rebuild packages that changed since last build
-                interactive mode, list can be edited before build start.
+	install: installs one or more packages when they're not yet installed
+		(list of installed packages is kept in /var/lib/butch.db unless
+		overridden via BUTCHDB env var.)
+	rebuild: installs one or more packages even when they're already
+		installed
+	prefetch: only download the given package and all of its dependencies,
+		unless they're not already in $C
+	update: rebuild packages that changed since last build
+		interactive mode, list can be edited before build start.
 	outdated: display packages that have changed since they were installed
 
 EOF
@@ -224,7 +224,7 @@ start_build() {
 		echo "error: butch-merge failed"
 		exit 1
 	}
-        chmod +x $scrname
+	chmod +x $scrname
 	success=false
         $scrname </dev/null > $logname 2>&1 && success=true
 	if $success ; then

--- a/KEEP/bin/butch-core
+++ b/KEEP/bin/butch-core
@@ -215,6 +215,9 @@ is_downloaded() {
 	read resss_ <&3
 	test $resss_ = 1 && return 0 || return 1
 }
+allow_network() {
+	$AWKPROG -f $BINDIR/butch-printsec "$1" vars | grep -x 'need_net=1' >/dev/null 2>&1
+}
 start_build() {
 	scrname=$B/build_$1.sh
 	logname=$LOGPATH/build_$1.log
@@ -226,7 +229,15 @@ start_build() {
 	}
 	chmod +x $scrname
 	success=false
-        $scrname </dev/null > $logname 2>&1 && success=true
+	unsharecmd=
+	if ! allow_network "$1" ; then
+		if [ -x "$(command -v unshare)" ]; then
+			unsharecmd='unshare --net'
+		else
+			info "WARNING: Network access protection disabled. Is unshare installed?"
+		fi
+	fi
+	$unsharecmd $scrname </dev/null > $logname 2>&1 && success=true
 	if $success ; then
 		update_butchdb "$1" installed
 	else


### PR DESCRIPTION
Some pkgs I freeze by editing BUTCHDB pkgver to 999 for some pkg so
only update pkgs if the new version is greater than the one installed.

add need_net=1 var for pkgs that must use network access and build
pkgs without network access by default with unshare --net