### PR TITLE
add libtool as build dependency

### DIFF
--- a/pkg/xf86-video-intel
+++ b/pkg/xf86-video-intel
@@ -17,6 +17,7 @@ xcb-util
 [deps.host]
 autoconf
 automake
+libtool
 
 [build]
 patch -p1 < "$C"/xf86-video-intel-git.patch
@@ -36,4 +37,3 @@ LDFLAGS="-Wl,-z,lazy" \
 #  --enable-glamor \
 
 make DESTDIR="$butch_install_dir" -j$MAKE_THREADS install
-


### PR DESCRIPTION
"butch install xf86-video-intel" as it is fails if libtool isn't already on the system.

Here was the old fail output:

```
...
autoreconf: Entering directory `.'
autoreconf: configure.ac: not using Gettext
autoreconf: running: aclocal --force -I m4
autoreconf: configure.ac: tracing
autoreconf: running: libtoolize --copy --force
Can't exec "libtoolize": No such file or directory at /share/autoconf/Autom4te/FileUtils.pm line 345, <GEN3> line 6.
autoreconf: failed to run libtoolize: No such file or directory
autoreconf: libtoolize is needed because this package uses Libtool
```

Thanks.