### PR TITLE
rebuild the correct gcc version

### DIFF
--- a/utils/rebuild-stage1.sh
+++ b/utils/rebuild-stage1.sh
@@ -12,7 +12,7 @@ gmp
 mpfr
 mpc
 libelf
-gcc640
+gcc650
 musl
 jobflow
 patch


### PR DESCRIPTION
this a simple fix that just changes `gcc640` to `gcc650` in the rebuild script to match commit 19e237d.