### PR TITLE
zsh: relieve dependency on autoconf

### DIFF
--- a/pkg/zsh
+++ b/pkg/zsh
@@ -14,6 +14,9 @@ cp -f "$K"/config.sub .
   xconfflags="--host=$($CC -dumpmachine) \
   --with-sysroot=$butch_root_dir"
 
+# relieve dependency on autoconf
+sed -i '/autoheader/d' Makefile.in
+
 CPPFLAGS="-D_GNU_SOURCE" CFLAGS="$optcflags" CXXFLAGS="$optcflags" \
 LDFLAGS="$optldflags -Wl,-rpath-link=$butch_root_dir$butch_prefix/lib" \
   ./configure --enable-libc-musl -C --prefix="$butch_prefix" $xconfflags


### PR DESCRIPTION
zsh attempts to run the autoheader command as part of its Makefile.
this makes autoconf a dependency of zsh.
however, this command doesn't actually seem to *do* anything
besides dump a few files in autom4te.cache, so it's safe to delete it.