### PR TITLE
add Python 3 package

### DIFF
--- a/KEEP/python3-dont_write_bytecode.patch
+++ b/KEEP/python3-dont_write_bytecode.patch
@@ -1,0 +1,11 @@
+--- Python-3.7.3.org/Python/pylifecycle.c
++++ Python-3.7.3/Python/pylifecycle.c
+@@ -120,7 +120,7 @@
+ int Py_BytesWarningFlag = 0; /* Warn on str(bytes) and str(buffer) */
+ int Py_FrozenFlag = 0; /* Needed by getpath.c */
+ int Py_IgnoreEnvironmentFlag = 0; /* e.g. PYTHONPATH, PYTHONHOME */
+-int Py_DontWriteBytecodeFlag = 0; /* Suppress writing bytecode files (*.pyc) */
++int Py_DontWriteBytecodeFlag = 1; /* Suppress writing bytecode files (*.pyc) */
+ int Py_NoUserSiteDirectory = 0; /* for -s and site.py */
+ int Py_UnbufferedStdioFlag = 0; /* Unbuffered binary std{in,out,err} */
+ int Py_HashRandomizationFlag = 0; /* for -R and PYTHONHASHSEED */

--- a/KEEP/python3-pathsearch.patch
+++ b/KEEP/python3-pathsearch.patch
@@ -4,13 +4,13 @@
  reduce(wchar_t *dir)
  {
      size_t i = wcslen(dir);
-+    if (i == 1 && dir[0] == '/') {
++    if (i == 1 && dir[0] == SEP) {
 +        dir[0] = 0;
 +        return;
 +    }
      while (i > 0 && dir[i] != SEP)
          --i;
-+    if (i == 0 && dir[0] == '/') i = 1;
++    if (i == 0 && dir[0] == SEP) i = 1;
      dir[i] = '\0';
  }
  
@@ -72,7 +72,7 @@
      copy_absolute(exec_prefix, calculate->argv0_path, MAXPATHLEN+1);
      do {
          n = wcslen(exec_prefix);
-@@ -507,9 +535,15 @@
+@@ -507,9 +535,16 @@
          exec_prefix[n] = L'\0';
          reduce(exec_prefix);
      } while (exec_prefix[0]);
@@ -80,70 +80,77 @@
  
      /* Look at configure's EXEC_PREFIX */
 -    wcsncpy(exec_prefix, calculate->exec_prefix, MAXPATHLEN);
-+    if (strlen(EXEC_PREFIX))
++    if (strlen(EXEC_PREFIX)) {
 +        wcsncpy(exec_prefix, calculate->exec_prefix, MAXPATHLEN);
++    }
 +    else {
-+        exec_prefix[0] = '/';
-+        exec_prefix[1] = 0;
++        exec_prefix[0] = L'/';
++        exec_prefix[1] = L'\0';
 +    }
      exec_prefix[MAXPATHLEN] = L'\0';
      joinpath(exec_prefix, calculate->lib_python);
      joinpath(exec_prefix, L"lib-dynload");
-@@ -831,6 +865,20 @@
-     bufsz += wcslen(calculate->zip_path) + 1;
-     bufsz += wcslen(exec_prefix) + 1;
- 
-+    bufsz += wcslen(prefix);
-+    bufsz += wcslen(L"/");
-+    bufsz += wcslen(calculate->lib_python);
-+    bufsz += wcslen(L":");
-+    bufsz += wcslen(exec_prefix);
-+    bufsz += wcslen(L"/");
-+    bufsz += wcslen(calculate->lib_python);
-+    bufsz += wcslen(L"/lib-dynload:");
-+    bufsz += wcslen(prefix);
-+    bufsz += wcslen(L"/");
-+    bufsz += wcslen(calculate->lib_python);
-+    bufsz += wcslen(L"/site-packages");
-+    bufsz += 1;
-+
-     /* Allocate the buffer */
-     wchar_t *buf = PyMem_RawMalloc(bufsz * sizeof(wchar_t));
-     if (buf == NULL) {
-@@ -844,10 +892,6 @@
-         wcscat(buf, delimiter);
+@@ -828,8 +863,18 @@
+         defpath = delim + 1;
      }
  
--    /* Next is the default zip path */
+-    bufsz += wcslen(calculate->zip_path) + 1;
+-    bufsz += wcslen(exec_prefix) + 1;
++//  bufsz += wcslen(calculate->zip_path) + 1;
++    bufsz += wcslen(calculate->prefix) + 1;
++    bufsz += wcslen(calculate->lib_python) + 1;
++    bufsz += wcslen(calculate->exec_prefix) + 1;
++    bufsz += wcslen(calculate->lib_python) + 1;
++    bufsz += wcslen(L"lib-dynload") + 1;
++    bufsz += wcslen(calculate->prefix) + 1;
++    bufsz += wcslen(calculate->lib_python) + 1;
++    bufsz += wcslen(L"site-packages") + 1;
++    if (wcslen(exec_prefix)) {
++        bufsz += wcslen(exec_prefix) + 1;
++    }
+ 
+     /* Allocate the buffer */
+     wchar_t *buf = PyMem_RawMalloc(bufsz * sizeof(wchar_t));
+@@ -845,8 +890,8 @@
+     }
+ 
+     /* Next is the default zip path */
 -    wcscat(buf, calculate->zip_path);
 -    wcscat(buf, delimiter);
--
++//  wcscat(buf, calculate->zip_path);
++//  wcscat(buf, delimiter);
+ 
      /* Next goes merge of compile-time $PYTHONPATH with
       * dynamically located prefix.
-      */
-@@ -879,8 +923,28 @@
+@@ -879,8 +924,34 @@
      }
      wcscat(buf, delimiter);
  
--    /* Finally, on goes the directory for dynamic-load modules */
 +    /* Next is the default prefix path. if we don't add this,
 +       python will stupidly search for modules only in it's *DESTDIR* instead of prefix
 +       this is fundamentally incompatible with the way sabotage relocates
 +       packages */
-+    wcscat(buf, prefix);
-+    wcscat(buf, L"/");
-+    wcscat(buf, calculate->lib_python);
-+    wcscat(buf, L":");
-     wcscat(buf, exec_prefix);
-+    wcscat(buf, L"/");
-+    wcscat(buf, calculate->lib_python);
-+    wcscat(buf, L"/lib-dynload:");
-+    wcscat(buf, prefix);
-+    wcscat(buf, L"/");
-+    wcscat(buf, calculate->lib_python);
-+    wcscat(buf, L"/site-packages");
 +
-+    /* Finally, on goes the directory for dynamic-load modules */
++    wcscat(buf, calculate->prefix);
++    wcscat(buf, separator);
++    wcscat(buf, calculate->lib_python);
++    wcscat(buf, delimiter);
++
++    wcscat(buf, calculate->exec_prefix);
++    wcscat(buf, separator);
++    wcscat(buf, calculate->lib_python);
++    wcscat(buf, separator);
++    wcscat(buf, L"lib-dynload");
++    wcscat(buf, delimiter);
++
++    wcscat(buf, calculate->prefix);
++    wcscat(buf, separator);
++    wcscat(buf, calculate->lib_python);
++    wcscat(buf, separator);
++    wcscat(buf, L"site-packages");
++
+     /* Finally, on goes the directory for dynamic-load modules */
+-    wcscat(buf, exec_prefix);
 +    if (wcslen(exec_prefix)) {
 +        wcscat(buf, delimiter);
 +        wcscat(buf, exec_prefix);

--- a/KEEP/python3-pathsearch.patch
+++ b/KEEP/python3-pathsearch.patch
@@ -1,0 +1,153 @@
+--- Python-3.7.3.org/Modules/getpath.c
++++ Python-3.7.3/Modules/getpath.c
+@@ -155,8 +155,13 @@
+ reduce(wchar_t *dir)
+ {
+     size_t i = wcslen(dir);
++    if (i == 1 && dir[0] == '/') {
++        dir[0] = 0;
++        return;
++    }
+     while (i > 0 && dir[i] != SEP)
+         --i;
++    if (i == 0 && dir[0] == '/') i = 1;
+     dir[i] = '\0';
+ }
+ 
+@@ -354,6 +359,11 @@
+         return 1;
+     }
+ 
++    if (!access(PREFIX "/bin/python3", X_OK)) {
++        swprintf(prefix, sizeof prefix, L"%s", calculate->prefix);
++        return 1;
++    }
++
+     /* Check to see if argv[0] is in the build directory */
+     wcsncpy(prefix, calculate->argv0_path, MAXPATHLEN);
+     prefix[MAXPATHLEN] = L'\0';
+@@ -374,7 +384,13 @@
+         }
+     }
+ 
+-    /* Search from argv0_path, until root is found */
++    /* Search from argv0_path, until root is found
++     * judging from the path of the currently running
++     * program about where the prefix is completely
++     * bogus unless we're running the python interpreter
++     * itself.
++     */
++    if (!wcsstr(calculate->argv0_path, L"python")) goto skip_argv0_madness;
+     copy_absolute(prefix, calculate->argv0_path, MAXPATHLEN+1);
+     do {
+         n = wcslen(prefix);
+@@ -386,9 +402,15 @@
+         prefix[n] = L'\0';
+         reduce(prefix);
+     } while (prefix[0]);
++    skip_argv0_madness:
+ 
+     /* Look at configure's PREFIX */
+-    wcsncpy(prefix, calculate->prefix, MAXPATHLEN);
++    if (wcslen(calculate->prefix))
++        wcsncpy(prefix, calculate->prefix, MAXPATHLEN);
++    else {
++        prefix[0] = '/';
++        prefix[1] = 0;
++    }
+     prefix[MAXPATHLEN] = L'\0';
+     joinpath(prefix, calculate->lib_python);
+     joinpath(prefix, LANDMARK);
+@@ -495,7 +517,13 @@
+         }
+     }
+ 
++    if (!access(EXEC_PREFIX "/bin/python3", X_OK)) {
++        swprintf(exec_prefix, sizeof exec_prefix, L"%s", calculate->exec_prefix);
++        return 1;
++    }
++
+     /* Search from argv0_path, until root is found */
++    if (!wcsstr(calculate->argv0_path, L"python")) goto skip_argv0_madness;
+     copy_absolute(exec_prefix, calculate->argv0_path, MAXPATHLEN+1);
+     do {
+         n = wcslen(exec_prefix);
+@@ -507,9 +535,15 @@
+         exec_prefix[n] = L'\0';
+         reduce(exec_prefix);
+     } while (exec_prefix[0]);
++    skip_argv0_madness:
+ 
+     /* Look at configure's EXEC_PREFIX */
+-    wcsncpy(exec_prefix, calculate->exec_prefix, MAXPATHLEN);
++    if (strlen(EXEC_PREFIX))
++        wcsncpy(exec_prefix, calculate->exec_prefix, MAXPATHLEN);
++    else {
++        exec_prefix[0] = '/';
++        exec_prefix[1] = 0;
++    }
+     exec_prefix[MAXPATHLEN] = L'\0';
+     joinpath(exec_prefix, calculate->lib_python);
+     joinpath(exec_prefix, L"lib-dynload");
+@@ -831,6 +865,20 @@
+     bufsz += wcslen(calculate->zip_path) + 1;
+     bufsz += wcslen(exec_prefix) + 1;
+ 
++    bufsz += wcslen(prefix);
++    bufsz += wcslen(L"/");
++    bufsz += wcslen(calculate->lib_python);
++    bufsz += wcslen(L":");
++    bufsz += wcslen(exec_prefix);
++    bufsz += wcslen(L"/");
++    bufsz += wcslen(calculate->lib_python);
++    bufsz += wcslen(L"/lib-dynload:");
++    bufsz += wcslen(prefix);
++    bufsz += wcslen(L"/");
++    bufsz += wcslen(calculate->lib_python);
++    bufsz += wcslen(L"/site-packages");
++    bufsz += 1;
++
+     /* Allocate the buffer */
+     wchar_t *buf = PyMem_RawMalloc(bufsz * sizeof(wchar_t));
+     if (buf == NULL) {
+@@ -844,10 +892,6 @@
+         wcscat(buf, delimiter);
+     }
+ 
+-    /* Next is the default zip path */
+-    wcscat(buf, calculate->zip_path);
+-    wcscat(buf, delimiter);
+-
+     /* Next goes merge of compile-time $PYTHONPATH with
+      * dynamically located prefix.
+      */
+@@ -879,8 +923,28 @@
+     }
+     wcscat(buf, delimiter);
+ 
+-    /* Finally, on goes the directory for dynamic-load modules */
++    /* Next is the default prefix path. if we don't add this,
++       python will stupidly search for modules only in it's *DESTDIR* instead of prefix
++       this is fundamentally incompatible with the way sabotage relocates
++       packages */
++    wcscat(buf, prefix);
++    wcscat(buf, L"/");
++    wcscat(buf, calculate->lib_python);
++    wcscat(buf, L":");
+     wcscat(buf, exec_prefix);
++    wcscat(buf, L"/");
++    wcscat(buf, calculate->lib_python);
++    wcscat(buf, L"/lib-dynload:");
++    wcscat(buf, prefix);
++    wcscat(buf, L"/");
++    wcscat(buf, calculate->lib_python);
++    wcscat(buf, L"/site-packages");
++
++    /* Finally, on goes the directory for dynamic-load modules */
++    if (wcslen(exec_prefix)) {
++        wcscat(buf, delimiter);
++        wcscat(buf, exec_prefix);
++    }
+ 
+     config->module_search_path = buf;
+     return _Py_INIT_OK();

--- a/KEEP/python3-sysconfig-prefix.patch
+++ b/KEEP/python3-sysconfig-prefix.patch
@@ -1,0 +1,29 @@
+--- Python-3.7.3.org/Lib/distutils/sysconfig.py
++++ Python-3.7.3/Lib/distutils/sysconfig.py
+@@ -92,7 +92,7 @@
+     If 'prefix' is supplied, use it instead of sys.base_prefix or
+     sys.base_exec_prefix -- i.e., ignore 'plat_specific'.
+     """
+-    if prefix is None:
++    if prefix is None or prefix == '':
+         prefix = plat_specific and BASE_EXEC_PREFIX or BASE_PREFIX
+     if os.name == "posix":
+         if python_build:
+@@ -135,7 +135,7 @@
+     If 'prefix' is supplied, use it instead of sys.base_prefix or
+     sys.base_exec_prefix -- i.e., ignore 'plat_specific'.
+     """
+-    if prefix is None:
++    if prefix is None or prefix == '':
+         if standard_lib:
+             prefix = plat_specific and BASE_EXEC_PREFIX or BASE_PREFIX
+         else:
+@@ -189,7 +189,7 @@
+ 
+         if 'CC' in os.environ:
+             newcc = os.environ['CC']
+-            if (sys.platform == 'darwin'
++            if ((sys.platform == 'darwin' or os.name == 'posix')
+                     and 'LDSHARED' not in os.environ
+                     and ldshared.startswith(cc)):
+                 # On OS X, if CC is overridden, use that as the default

--- a/KEEP/python3-xcompile.patch
+++ b/KEEP/python3-xcompile.patch
@@ -1,0 +1,36 @@
+--- Python-3.7.3.org/Makefile.pre.in
++++ Python-3.7.3/Makefile.pre.in
+@@ -1393,33 +1393,6 @@
+ 		$(INSTALL_DATA) $(srcdir)/Modules/xxmodule.c \
+ 			$(DESTDIR)$(LIBDEST)/distutils/tests ; \
+ 	fi
+-	-PYTHONPATH=$(DESTDIR)$(LIBDEST)  $(RUNSHARED) \
+-		$(PYTHON_FOR_BUILD) -Wi $(DESTDIR)$(LIBDEST)/compileall.py \
+-		-d $(LIBDEST) -f \
+-		-x 'bad_coding|badsyntax|site-packages|lib2to3/tests/data' \
+-		$(DESTDIR)$(LIBDEST)
+-	-PYTHONPATH=$(DESTDIR)$(LIBDEST) $(RUNSHARED) \
+-		$(PYTHON_FOR_BUILD) -Wi -O $(DESTDIR)$(LIBDEST)/compileall.py \
+-		-d $(LIBDEST) -f \
+-		-x 'bad_coding|badsyntax|site-packages|lib2to3/tests/data' \
+-		$(DESTDIR)$(LIBDEST)
+-	-PYTHONPATH=$(DESTDIR)$(LIBDEST) $(RUNSHARED) \
+-		$(PYTHON_FOR_BUILD) -Wi -OO $(DESTDIR)$(LIBDEST)/compileall.py \
+-		-d $(LIBDEST) -f \
+-		-x 'bad_coding|badsyntax|site-packages|lib2to3/tests/data' \
+-		$(DESTDIR)$(LIBDEST)
+-	-PYTHONPATH=$(DESTDIR)$(LIBDEST) $(RUNSHARED) \
+-		$(PYTHON_FOR_BUILD) -Wi $(DESTDIR)$(LIBDEST)/compileall.py \
+-		-d $(LIBDEST)/site-packages -f \
+-		-x badsyntax $(DESTDIR)$(LIBDEST)/site-packages
+-	-PYTHONPATH=$(DESTDIR)$(LIBDEST) $(RUNSHARED) \
+-		$(PYTHON_FOR_BUILD) -Wi -O $(DESTDIR)$(LIBDEST)/compileall.py \
+-		-d $(LIBDEST)/site-packages -f \
+-		-x badsyntax $(DESTDIR)$(LIBDEST)/site-packages
+-	-PYTHONPATH=$(DESTDIR)$(LIBDEST) $(RUNSHARED) \
+-		$(PYTHON_FOR_BUILD) -Wi -OO $(DESTDIR)$(LIBDEST)/compileall.py \
+-		-d $(LIBDEST)/site-packages -f \
+-		-x badsyntax $(DESTDIR)$(LIBDEST)/site-packages
+ 	-PYTHONPATH=$(DESTDIR)$(LIBDEST) $(RUNSHARED) \
+ 		$(PYTHON_FOR_BUILD) -m lib2to3.pgen2.driver $(DESTDIR)$(LIBDEST)/lib2to3/Grammar.txt
+ 	-PYTHONPATH=$(DESTDIR)$(LIBDEST) $(RUNSHARED) \

--- a/pkg/python3
+++ b/pkg/python3
@@ -1,0 +1,130 @@
+[mirrors]
+https://www.python.org/ftp/python/3.7.3/Python-3.7.3.tar.xz
+# http://sources.buildroot.net/Python-3.6.4.tar.xz
+
+[vars]
+filesize=17108364
+sha512=6d9b7c0f1764e0f655a39430a3af6f7b5e3c9b7166c042e780677a54b17ad4ca6d0d9cba262c82b1b70bba8f7c28883dad4cc0d7cc194fc7d2c1b5f4f08a763a
+pkgver=1
+desc='interpreter for the python 3.x scripting language'
+
+[deps]
+musl
+curses
+libressl
+bzip2
+expat
+libffi
+libedit
+
+[build]
+# work around buggy installer which puts stuff into prefix directly (omitting destdir) when
+# the prefix equals "/"
+[ "$butch_prefix" = "/" ] && butch_prefix=
+
+# python can't deal with prefix= or prefix=/ correctly.
+# it will emit empty PREFIX and EXEC_PREFIX macros into pyconfig.h
+# additionally it searches for stuff only relative to its own binary.
+# this doesn't work well with our symlink relocation strategy.
+patch -p1 < "$K"/python3-pathsearch.patch
+patch -p1 < "$K"/python3-xcompile.patch
+#patch -p1 < "$K"/python3-includedirs.patch # TODO
+#patch -p1 < "$K"/python3-UTF-8.patch # TODO
+patch -p1 < "$K"/python3-sysconfig-prefix.patch # TODO: incomplete
+# if PYTHON_SMALL_AND_SLOW is set, we disable automatic creation of .pyc and
+# .pyo bytecode files. the result is small delay on startup (up to 2.5x slower)
+# but substantial savings in disk space (31 vs 22 MB on x86_64)).
+if test "$PYTHON_SMALL_AND_SLOW" = 1 ; then
+  patch -p1 < "$K"/python3-dont_write_bytecode.patch
+else
+  # the patch to disable python .pyo optimization would go here,
+  # but it isn't necessary for now.
+  :
+fi
+
+# TODO:
+# below lines are commented out, because even though they should improve libedit support,
+# the resulting readline module doesn't deal correctly with tab completion.
+# for example "completing text" code from https://pymotw.com/2/readline/
+# in order to use it, one has to uncomment and add -DLIBEDIT_SUPPORT to EXTRA_CFLAGS
+#
+# official libedit support is mistakenly only added for __APPLE__
+#sed -i 's/__APPLE__/LIBEDIT_SUPPORT/g' Modules/readline.c
+# patch out unnecessary strdup/setlocale calls, which workaround a GNU readline bug
+#sed -i 's/HAVE_SETLOCALE/HAVE_SETLOCALE) \&\& !defined(LIBEDIT_SUPPORT/g' Modules/readline.c
+
+sed -i 's@return readline@return feedline@' configure
+
+[ -n "$CROSS_COMPILE" ] && \
+  xconfflags="--host=$($CC -dumpmachine) --build=$($HOSTCC -dumpmachine)"
+
+# borrowed from archlinux:
+sed -i -e "s|^#.* /usr/local/bin/python|#!/bin/python3|" Lib/cgi.py
+find . -name '*.py' -exec \
+  sed -i "s|#[ ]*![ ]*/usr/bin/env python$|#!/usr/bin/env python3|" {} +
+
+CFLAGS="-D_GNU_SOURCE -D_BSD_SOURCE -fPIC" \
+OPT="$optcflags" \
+LDFLAGS="$optldflags -lncursesw -lterminfo" \
+./configure -C --prefix="$butch_prefix" \
+  --with-system-expat --with-system-ffi $xconfflags \
+  --without-cxx-main \
+  ac_cv_lib_readline_rl_callback_handler_install=no \
+  ac_cv_lib_readline_rl_pre_input_hook=no \
+  ac_cv_lib_readline_rl_completion_display_matches_hook=no \
+  ac_cv_lib_readline_rl_completion_matches=yes \
+  ac_cv_have_long_long_format=yes \
+  ac_cv_file__dev_ptc=no \
+  ac_cv_file__dev_ptmx=yes
+
+if [ -n "$CROSS_COMPILE" ] ; then
+  cp pyconfig.h pyconfig.h.target
+  for i in SIZEOF_LONG SIZEOF_PTHREAD_T SIZEOF_SIZE_T SIZEOF_TIME_T SIZEOF_VOID_P SIZEOF_UINTPTR_T ; do
+    sed -i 's,#define '$i',//,' pyconfig.h
+  done
+  printf "%s\n" 'int main() { printf("%zu\n", sizeof(time_t)); return 0;}' > foo.c
+  $HOSTCC -include time.h -include stdio.h foo.c
+  l=$(./a.out)
+cat << EOF >> pyconfig.h
+#define SIZEOF_LONG __SIZEOF_LONG__
+#define SIZEOF_PTHREAD_T SIZEOF_LONG
+#define SIZEOF_SIZE_T SIZEOF_LONG
+#define SIZEOF_VOID_P SIZEOF_LONG
+#define SIZEOF_UINTPTR_T SIZEOF_LONG
+#define SIZEOF_TIME_T $l
+EOF
+  make Parser/pgen CC="$HOSTCC" -j$MAKE_THREADS
+  cp pyconfig.h.target pyconfig.h
+else
+  make Parser/pgen -j$MAKE_THREADS
+fi
+
+make -j$MAKE_THREADS
+
+make DESTDIR="$butch_install_dir" altinstall
+
+dest="$butch_install_dir""$butch_prefix"
+# removing tests
+for test in sqlite3/test email/test ctypes/test test unittest/test tkinter/test \
+            bsddb/test json/tests lib2to3/tests distutils/tests tests ; do
+  rm -rf "$dest"/lib/python3.7/"$test"
+done
+
+# remove hardcoded CFLAGS interfering with cross builds
+# note: OPT is only used if CFLAGS are exported in environment.
+sed -i "s,'OPT': '.*','OPT': ''," "$dest"/lib/python3.7/_sysconfigdata_*.py
+
+if test "$PYTHON_SMALL_AND_SLOW" = 1 ; then
+  # removing precompiled python code, if any
+  find "$dest"/lib/python3.7/ -name '*.pyo' -or -name '*.pyc' -delete
+else
+  # precompile all .pyc files now rather than on first use, so they're part of
+  # the package directory
+  test -n "$CROSS_COMPILE" || ./python -E Lib/compileall.py "$dest"/lib/python3.7
+fi
+
+# create symlinks without the major version number in them
+for bin in idle3.7 2to3-3.7 pip3.7 easy_install-3.7 \
+           python3.7 pyvenv-3.7 python3.7m pydoc3.7 python3.7m-config ; do
+  ln -sf "$dest/bin/$bin" "$dest/bin/${bin/3.7/3}"
+done

--- a/pkg/python3
+++ b/pkg/python3
@@ -1,6 +1,6 @@
 [mirrors]
 https://www.python.org/ftp/python/3.7.3/Python-3.7.3.tar.xz
-# http://sources.buildroot.net/Python-3.6.4.tar.xz
+http://sources.buildroot.net/python3/Python-3.7.3.tar.xz
 
 [vars]
 filesize=17108364

--- a/pkg/python3
+++ b/pkg/python3
@@ -18,8 +18,8 @@ libffi
 libedit
 
 [build]
-# work around buggy installer which puts stuff into prefix directly (omitting destdir) when
-# the prefix equals "/"
+# work around buggy installer which puts stuff into prefix directly
+# (omitting destdir) when the prefix equals "/"
 [ "$butch_prefix" = "/" ] && butch_prefix=
 
 # python can't deal with prefix= or prefix=/ correctly.


### PR DESCRIPTION
as requested, but there are a few things to consider before merging:

* no cross-compilation support (the big one)
* no .pyo patch (pretty minor)
* <strike>no alternate mirror (easy fix)</strike>

the build script and patches largely match those of the python2 package, so credits to its author. a couple lines were also borrowed from Arch Linux's package to make various scripts invoke python3 instead of defaulting to python2.