### PR TITLE
fix ssp, bumps and libsodium

### DIFF
--- a/KEEP/__stack_chk_fail_local.c
+++ b/KEEP/__stack_chk_fail_local.c
@@ -1,0 +1,2 @@
+extern void __stack_chk_fail(void);
+void __attribute__((visibility ("hidden"))) __stack_chk_fail_local(void) { __stack_chk_fail(); }

--- a/pkg/fte
+++ b/pkg/fte
@@ -3,7 +3,7 @@ http://prdownloads.sourceforge.net/fte/fte-20020324-src.zip
 
 [vars]
 filesize=625459
-sha512=50a653a67ad135683df25d94e6a722e2b0e8be2da81d6c59b2ac30d905130b127c53bf2c$
+sha512=50a653a67ad135683df25d94e6a722e2b0e8be2da81d6c59b2ac30d905130b127c53bf2c621585c109dad3a58a22cff36a7b04773a9816ddf7d0ffab03dc86b1
 tardir=fte
 pkgver=1
 desc='text editor'

--- a/pkg/libsodium
+++ b/pkg/libsodium
@@ -15,7 +15,9 @@ pkgver=2
 
 CPPFLAGS="-D_GNU_SOURCE" CFLAGS="$optcflags" CXXFLAGS="$optcflags" \
 LDFLAGS="$optldflags -Wl,-rpath-link=$butch_root_dir$butch_prefix/lib" \
-  ./configure -C --prefix="$butch_prefix" --disable-nls $xconfflags
+  ./configure -C --prefix="$butch_prefix" --disable-nls --disable-ssp $xconfflags \
+	ac_cv_tls=__thread \
+	ax_cv_check_cflags___ftls_model_local_dynamic=no
 
 make V=1 -j$MAKE_THREADS
 make DESTDIR="$butch_install_dir" install

--- a/pkg/libsodium
+++ b/pkg/libsodium
@@ -1,10 +1,11 @@
 [mirrors]
-https://download.libsodium.org/libsodium/releases/libsodium-1.0.17.tar.gz
+https://download.libsodium.org/libsodium/releases/libsodium-1.0.18-stable.tar.gz
 
 [vars]
-filesize=1911910
-sha512=7cc9e4f11e656008ce9dff735acea95acbcb91ae4936de4d26f7798093766a77c373e9bd4a7b45b60ef8a11de6c55bc8dcac13bebf8c23c671d0536430501da1
-pkgver=2
+filesize=1852767
+sha512=5d421049ec58e68fe5624ce85c1a0a765591e2ded428cd4ec8e10ddae475d229aa0eb40d6a6e7f96926fd921a12cef75a015244e18b803e0f436eaf0fdc9a007
+pkgver=3
+tardir=libsodium-stable
 
 [deps]
 

--- a/pkg/musl
+++ b/pkg/musl
@@ -46,3 +46,11 @@ sed -i "s,PPPP,$butch_prefix," "$musl_gcc"
 #this should speed up dynamic linker path search
 mkdir -p "$dest"/etc
 printf "%s\n" "$butch_prefix"/lib > "$dest"/etc/ld-musl-$A.path
+
+## fix ssp on i?86
+case "$A" in
+	i?86)
+		$CC $optldflags $optcflags -c "$K/__stack_chk_fail_local.c" -o __stack_chk_fail_local.o
+		"$CROSS_COMPILE"ar rcs "$dest/lib/libssp_nonshared.a" __stack_chk_fail_local.o
+	;;
+esac

--- a/pkg/python
+++ b/pkg/python
@@ -16,6 +16,7 @@ bzip2
 expat
 libffi
 libedit
+sqlite
 
 [build]
 # work around buggy installer which puts stuff into prefix directly (omitting destdir) when

--- a/pkg/python-lxml
+++ b/pkg/python-lxml
@@ -12,6 +12,9 @@ python
 [deps.host]
 python
 
+[deps]
+libxml2
+
 [build]
 export CFLAGS="$optcflags"
 python setup.py build

--- a/pkg/python-twisted
+++ b/pkg/python-twisted
@@ -1,9 +1,10 @@
 [mirrors]
-https://pypi.python.org/packages/source/T/Twisted/Twisted-16.1.1.tar.bz2
+https://files.pythonhosted.org/packages/79/59/035de19362320e632301ed7bbde23e4c8cd6fc5e2f1cf8d354cdba857854/Twisted-19.2.1.tar.bz2
 
 [vars]
-filesize=2938611
-sha512=2a7e9eddace9f8025c5a2150e09d8154c9751235e7c5fe8a6fbcdc6121e3c77d7c954a126d37265d90ad19a02cfcba87150a6ae8226861143e3556bbe03c9b
+filesize=3097651
+sha512=b358c3082a9005f7065da182cec3561d77aa34f21fc1bb20b1acdb1ad3ac7e8b0793c5f7189baec7cfa79dd19a97c3ded9381e4e376a770108f7f6b318bec5f3
+pkgver=2
 
 [deps.run]
 python


### PR DESCRIPTION
* musl: fix ssp on i?86
* python: add sqlite dep.
* libsodium: add patch
* python-twisted: bump to 19.2.1
* fte: fix sha512