### PR TITLE
Bumps and fixes

### DIFF
--- a/pkg/libsodium
+++ b/pkg/libsodium
@@ -1,11 +1,10 @@
 [mirrors]
-https://download.libsodium.org/libsodium/releases/libsodium-1.0.18-stable.tar.gz
+https://download.libsodium.org/libsodium/releases/libsodium-1.0.18.tar.gz
 
 [vars]
-filesize=1852767
-sha512=5d421049ec58e68fe5624ce85c1a0a765591e2ded428cd4ec8e10ddae475d229aa0eb40d6a6e7f96926fd921a12cef75a015244e18b803e0f436eaf0fdc9a007
+filesize=1919817
+sha512=17e8638e46d8f6f7d024fe5559eccf2b8baf23e143fadd472a7d29d228b186d86686a5e6920385fe2020729119a5f12f989c3a782afbd05a8db4819bb18666ef
 pkgver=3
-tardir=libsodium-stable
 
 [deps]
 

--- a/pkg/popt
+++ b/pkg/popt
@@ -1,5 +1,5 @@
 [mirrors]
-http://rpm5.org/files/popt/popt-1.16.tar.gz
+http://ftp.rpm.org/mirror/popt/popt-1.16.tar.gz
 
 [vars]
 filesize=702769

--- a/pkg/python-pyasn1
+++ b/pkg/python-pyasn1
@@ -1,10 +1,10 @@
 [mirrors]
-https://pypi.python.org/packages/57/f7/c18a86169bb9995a69195177b23e736776b347fd92592da0c3cac9f1a724/pyasn1-0.2.2.tar.gz
+https://files.pythonhosted.org/packages/e3/12/dfffc84b783e280e942409d6b651fe4a5a746433c34589da7362db2c99c6/pyasn1-0.4.6.tar.gz
 
 [vars]
-filesize=90946
-sha512=c26d84cfea8e99daebbec3f1843615609f102b14345905b4e34ddfd91feae8c8741bc26a35efb08f4c766f02db5225e77c7b82b22df888f237bba31529553a60
-pkgver=1
+filesize=128216
+sha512=0d7dba175f292a136a34df0dadb90392bff1dac93ab2d04697fcd3e03f5bb8367a8e68dbfcc536ea9effd6292a459f24766f29f512161724fa405accb86617c5
+pkgver=2
 uchkurl=https://pypi.org/project/pyasn1/
 
 [deps.run]

--- a/pkg/python-six
+++ b/pkg/python-six
@@ -1,10 +1,10 @@
 [mirrors]
-https://pypi.python.org/packages/b3/b2/238e2590826bfdd113244a40d9d3eb26918bd798fc187e2360a8367068db/six-1.10.0.tar.gz
+https://files.pythonhosted.org/packages/dd/bf/4138e7bfb757de47d1f4b6994648ec67a51efe58fa907c1e11e350cddfca/six-1.12.0.tar.gz
 
 [vars]
-filesize=29630
-sha512=9a53b7bc8f7e8b358c930eaecf91cc5639176a699830153f586780c3e6d637f1bd31349a69c383574f99da19cb3a36524e7733a318f3572b27aefb69c6409c2e
-pkgver=1
+filesize=32725
+sha512=937728372edf1e0ac13bbd706723d0de35e015c30d0ae41f789c5ed2e3669bb0db70cdc6e036ec2d437a6c4aa0d5d1e727b6d09ac34cca7e4e92e5d3b4775151
+pkgver=2
 uchkurl=https://pypi.org/project/six/
 
 [deps.run]


### PR DESCRIPTION
python-pyasn1: bump to 0.4.6
python-six: bump to 1.12.0
popt: add secondary mirror (current returns host not found)
libsodium: fix filesize and sha512