### PR TITLE
Bump gnutls, libtasn1 and syslinux6

### DIFF
--- a/KEEP/syslinux6-ext4_fix_64bit_feature.patch
+++ b/KEEP/syslinux6-ext4_fix_64bit_feature.patch
@@ -1,0 +1,101 @@
+From af7e95c32cea40c1e443ae301e64b27f068b4915 Mon Sep 17 00:00:00 2001
+From: Paulo Alcantara <pcacjr@zytor.com>
+Date: Wed, 11 Oct 2017 07:00:31 -0400
+Subject: ext4: Fix 64bit feature
+
+As per ext4 specification:
+
+> In ext2, ext3, and ext4 (when the 64bit feature is not enabled), the
+> block group descriptor was only 32 bytes long and therefore ends at
+> bg_checksum. On an ext4 filesystem with the 64bit feature enabled, the
+> block group descriptor expands to at least the 64 bytes described below;
+> the size is stored in the superblock.
+
+Since block group descriptor has been expanded to 64 bytes long (when 64
+bit feature is enabled), we cannot index ext2_group_desc and return it
+*directly* -- as we did it in ext2_get_group_desc -- it's still 32 bytes
+long.
+
+Instead, use s_desc_size field from superblock to correctly index and
+return block group descriptors.
+
+Cc: H. Peter Anvin <hpa@zytor.com>
+Cc: Gene Cumm <gene.cumm@gmail.com>
+Signed-off-by: Paulo Alcantara <pcacjr@zytor.com>
+---
+ core/fs/ext2/ext2.c    | 23 ++++++++++++++---------
+ core/fs/ext2/ext2_fs.h |  1 +
+ 2 files changed, 15 insertions(+), 9 deletions(-)
+
+diff --git a/core/fs/ext2/ext2.c b/core/fs/ext2/ext2.c
+index 76bd1d5a..4bc0a535 100644
+--- a/core/fs/ext2/ext2.c
++++ b/core/fs/ext2/ext2.c
+@@ -25,22 +25,17 @@ static enum dirent_type ext2_cvt_type(unsigned int d_file_type)
+ 	return inode_type[d_file_type];
+ }
+ 
+-/*
+- * get the group's descriptor of group_num
+- */
+-static const struct ext2_group_desc *
+-ext2_get_group_desc(struct fs_info *fs, uint32_t group_num)
++static const void *__ext2_get_group_desc(struct fs_info *fs, uint32_t group_num)
+ {
+     struct ext2_sb_info *sbi = EXT2_SB(fs);
+     uint32_t desc_block, desc_index;
+-    const struct ext2_group_desc *desc_data_block;
++    uint8_t *p;
+ 
+     if (group_num >= sbi->s_groups_count) {
+ 	printf ("ext2_get_group_desc"
+ 		"block_group >= groups_count - "
+ 		"block_group = %d, groups_count = %d",
+ 		group_num, sbi->s_groups_count);
+-
+ 	return NULL;
+     }
+ 
+@@ -49,8 +44,17 @@ ext2_get_group_desc(struct fs_info *fs, uint32_t group_num)
+ 
+     desc_block += sbi->s_first_data_block + 1;
+ 
+-    desc_data_block = get_cache(fs->fs_dev, desc_block);
+-    return &desc_data_block[desc_index];
++    p = get_cache(fs->fs_dev, desc_block);
++    return p + sbi->s_desc_size * desc_index;
++}
++
++/*
++ * get the group's descriptor of group_num
++ */
++static inline const struct ext2_group_desc *
++ext2_get_group_desc(struct fs_info *fs, uint32_t group_num)
++{
++    return __ext2_get_group_desc(fs, group_num);
+ }
+ 
+ /*
+@@ -306,6 +310,7 @@ static int ext2_fs_init(struct fs_info *fs)
+     if (sb.s_desc_size < sizeof(struct ext2_group_desc))
+ 	sb.s_desc_size = sizeof(struct ext2_group_desc);
+     sbi->s_desc_per_block   = BLOCK_SIZE(fs) / sb.s_desc_size;
++    sbi->s_desc_size = sb.s_desc_size;
+     sbi->s_groups_count     = (sb.s_blocks_count - sb.s_first_data_block
+ 			       + EXT2_BLOCKS_PER_GROUP(fs) - 1)
+ 	                      / EXT2_BLOCKS_PER_GROUP(fs);
+diff --git a/core/fs/ext2/ext2_fs.h b/core/fs/ext2/ext2_fs.h
+index 803a9954..d8d07ebd 100644
+--- a/core/fs/ext2/ext2_fs.h
++++ b/core/fs/ext2/ext2_fs.h
+@@ -278,6 +278,7 @@ struct ext2_sb_info {
+     uint32_t s_first_data_block;	/* First Data Block */
+     int      s_inode_size;
+     uint8_t  s_uuid[16];	/* 128-bit uuid for volume */
++    int      s_desc_size;	/* size of group descriptor */
+ };
+ 
+ static inline struct ext2_sb_info *EXT2_SB(struct fs_info *fs)
+-- 
+cgit v1.2.1
+

--- a/pkg/gnutls
+++ b/pkg/gnutls
@@ -1,11 +1,12 @@
 [mirrors]
-ftp://ftp.gnutls.org/gcrypt/gnutls/v3.6/gnutls-3.6.9.tar.xz
-http://ftp.heanet.ie/mirrors/ftp.gnupg.org/gcrypt/gnutls/v3.6/gnutls-3.6.9.tar.xz
+https://www.gnupg.org/ftp/gcrypt/gnutls/v3.6/gnutls-3.6.13.tar.xz
+http://ftp.heanet.ie/mirrors/ftp.gnupg.org/gcrypt/gnutls/v3.6/gnutls-3.6.13.tar.xz
+http://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/gnutls/v3.6/gnutls-3.6.13.tar.xz
 
 [vars]
-filesize=5773928
-sha512=a9fd0f4edae4c081d5c539ba2e5574a4d7294bc00c5c73ea25ce26cb7fd126299c2842a282d45ef5cf0544108f27066e587df28776bc7915143d190d7d5b9d07
-pkgver=5
+filesize=5958956
+sha512=23581952cb72c9a34f378c002bb62413d5a1243b74b48ad8dc49eaea4020d33c550f8dc1dd374cf7fbfa4187b0ca1c5698c8a0430398268a8b8a863f8633305c
+pkgver=6
 desc='C library implementing the SSL, TLS and DTLS protocols'
 
 [deps]

--- a/pkg/libtasn1
+++ b/pkg/libtasn1
@@ -1,10 +1,11 @@
 [mirrors]
-http://ftp.gnu.org/gnu/libtasn1/libtasn1-4.15.0.tar.gz
+https://ftp.gnu.org/gnu/libtasn1/libtasn1-4.16.0.tar.gz
+http://www.nic.funet.fi/pub/gnu/ftp.gnu.org/pub/gnu/libtasn1/libtasn1-4.16.0.tar.gz
 
 [vars]
-filesize=1800713
-sha512=a8095aebf57a0b482027d06e0ee6978946f267b57bf2db3c891c4656ca35250cc1f72e2e90f4cc0ddbdf6cd2b1783881a62d495a57ad4a98684f8d037307552d
-pkgver=5
+filesize=1812442
+sha512=b356249535d5d592f9b59de39d21e26dd0f3f00ea47c9cef292cdd878042ea41ecbb7c8d2f02ac5839f5210092fe92a25acd343260ddf644887b031b167c2e71
+pkgver=6
 desc='ASN.1 library used by GnuTLS and others'
 
 [deps]

--- a/pkg/syslinux6
+++ b/pkg/syslinux6
@@ -8,17 +8,16 @@ perl
 nasm
 
 [vars]
-filesize=9772883
-sha512=ca3da9d7f5f1c4ccc2eaa1cc33f5d2bb4afe2518dadeb863169ba2cce023c62112e5312181b047ce868a217e36f9b103622cf2e0e8559c3b7de35ad191388450
-pkgver=3
+filesize=6855224
+sha512=dd2b2916962b9e93bc1e714182e3ca2a727a229b8afabe913050bcfdd43ee2af51ee3acf79121d8c20caf434583efaa7f3196871e0e07c04d82191323a50fe31
+pkgver=4
 
 [mirrors]
-ftp://www.kernel.org/pub/linux/utils/boot/syslinux/syslinux-6.02.tar.bz2
-http://www.kernel.org/pub/linux/utils/boot/syslinux/syslinux-6.02.tar.bz2
-http://www.kernel.org/pub/linux/utils/boot/syslinux/6.xx/syslinux-6.02.tar.bz2
-http://ftp.wh2.tu-dresden.de/pub/mirrors/kernel.org/linux/utils/boot/syslinux/syslinux-6.02.tar.bz2
-http://ftp.hosteurope.de/mirror/ftp.kernel.org/pub/linux/utils/boot/syslinux/syslinux-6.02.tar.bz2
-http://ftp.uni-ulm.de/pub/mirrors/kernel.org/utils/boot/syslinux/6.xx/syslinux-6.02.tar.bz2
+https://mirrors.edge.kernel.org/pub/linux/utils/boot/syslinux/6.xx/syslinux-6.03.tar.xz
+http://www.kernel.org/pub/linux/utils/boot/syslinux/6.xx/syslinux-6.03.tar.xz
+http://ftp.wh2.tu-dresden.de/pub/mirrors/kernel.org/linux/utils/boot/syslinux/syslinux-6.03.tar.xz
+http://ftp.hosteurope.de/mirror/ftp.kernel.org/pub/linux/utils/boot/syslinux/syslinux-6.03.tar.xz
+http://ftp.uni-ulm.de/pub/mirrors/kernel.org/utils/boot/syslinux/6.xx/syslinux-6.03.tar.xz
 
 [build]
 isx86=0
@@ -32,6 +31,8 @@ esac
     echo "ERROR: syslinux6 only supports the intel architecture"
     exit 0
 }
+
+patch -p1 < "$K"/syslinux6-ext4_fix_64bit_feature.patch
 
 # We dont use sbin
 sed -i 's,/sbin,/bin,' syslinux.spec mk/syslinux.mk


### PR DESCRIPTION
Couple of package updates. Build tested including some packages that depend on gnutls.

These updates include important fixes for x86:
- gnutls 3.6.9 had a bug that broke build on x86
- syslinux6 was unable to boot when installed on partition with ext4 filesystem having 64bit feature enabled (default when creating ext4 filesystem).