### PR TITLE
Some fixes

### DIFF
--- a/pkg/go
+++ b/pkg/go
@@ -11,7 +11,7 @@ pkgver=2
 go14
 
 [build]
-cd ./src && GOROOT_BOOTSTRAP="$butch_root_dir$butch_prefix"/opt/go14 ./make.bash
+cd ./src && CGO_ENABLED=0 GOROOT_BOOTSTRAP="$butch_root_dir$butch_prefix"/opt/go14 ./make.bash
 cd ../../ && cp -ar go/* "$butch_install_dir""$butch_prefix"
 [ -h "$butch_root_dir""$butch_prefix"/bin/go ] && rm "$butch_root_dir""$butch_prefix"/bin/go
 [ -h "$butch_root_dir""$butch_prefix"/bin/gofmt ] && rm "$butch_root_dir""$butch_prefix"/bin/gofmt

--- a/pkg/openssh
+++ b/pkg/openssh
@@ -62,7 +62,6 @@ Ciphers chacha20-poly1305@openssh.com,aes128-gcm@openssh.com,aes256-gcm@openssh.
 MACs hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-512
 HostKey /etc/ssh/ssh_host_ed25519_key
 HostKey /etc/ssh/ssh_host_rsa_key
-UsePrivilegeSeparation sandbox
 AuthorizedKeysFile  .ssh/authorized_keys
 #X11Forwarding yes
 AcceptEnv LANG LC_*

--- a/pkg/python-beautifulsoup4
+++ b/pkg/python-beautifulsoup4
@@ -12,6 +12,7 @@ python
 
 [deps.host]
 python
+python-setuptools
 
 [build]
 python setup.py build


### PR DESCRIPTION
* openssh: disabled deprecated "UsePrivilegeSeparation" option in sshd_config
* python-beautifulsoup4: add missing python-setuptools dependency
* go: define "CGO_ENABLED=0" on bootstrap