### PR TITLE
Fixes (lm-sensors, go14)

### DIFF
--- a/pkg/go14
+++ b/pkg/go14
@@ -16,7 +16,7 @@ echo "it tries to build and execute stuff built with \$CC"
 exit 1
 }
 patch -p1 < "$K"/go.patch
-cd ./src && ./make.bash
+cd ./src && CGO_ENABLED=0 ./make.bash
 cd ../../ && cp -ar go/* "$butch_install_dir""$butch_prefix"
 [ -h "$butch_root_dir""$butch_prefix"/bin/go ] && rm "$butch_root_dir""$butch_prefix"/bin/go
 [ -h "$butch_root_dir""$butch_prefix"/bin/gofmt ] && rm "$butch_root_dir""$butch_prefix"/bin/gofmt

--- a/pkg/lm-sensors
+++ b/pkg/lm-sensors
@@ -7,6 +7,8 @@ sha512=993064bd14b855c1ae8c057e89313df5b3d5efe441fb2e8c3e508f42bb15658564df2563f
 tardir=lm_sensors-3.4.0
 
 [deps]
+bison
+flex
 
 [build]
 patch -p1 < "$K"/lm_sensors.patch

--- a/pkg/lm-sensors
+++ b/pkg/lm-sensors
@@ -7,6 +7,8 @@ sha512=993064bd14b855c1ae8c057e89313df5b3d5efe441fb2e8c3e508f42bb15658564df2563f
 tardir=lm_sensors-3.4.0
 
 [deps]
+
+[deps.host]
 bison
 flex
 


### PR DESCRIPTION
lm-sensors: add missing bison and flex dependencies
go14: use CGO_ENABLED=0 as well