### PR TITLE
Zig: Bump to 0.8.0.

### DIFF
--- a/KEEP/cmake-isystem.patch
+++ b/KEEP/cmake-isystem.patch
@@ -1,9 +1,9 @@
 --- a/Modules/Compiler/Clang.cmake
 +++ b/Modules/Compiler/Clang.cmake
-@@ -20,7 +20,8 @@
-   macro(__compiler_clang lang)
-     __compiler_gnu(${lang})
-     set(CMAKE_${lang}_COMPILE_OPTIONS_PIE "-fPIE")
+@@ -32,7 +32,8 @@
+       set(CMAKE_${lang}_LINK_OPTIONS_PIE ${CMAKE_${lang}_COMPILE_OPTIONS_PIE} -Xlinker -pie)
+       set(CMAKE_${lang}_LINK_OPTIONS_NO_PIE -Xlinker -no_pie)
+     endif()
 -    set(CMAKE_INCLUDE_SYSTEM_FLAG_${lang} "-isystem ")
 +    set(CMAKE_INCLUDE_SYSTEM_FLAG_C)
 +    set(CMAKE_INCLUDE_SYSTEM_FLAG_CXX)
@@ -12,7 +12,7 @@
        set(CMAKE_${lang}_COMPILE_OPTIONS_TARGET "-target ")
 --- a/Modules/Compiler/GNU.cmake
 +++ b/Modules/Compiler/GNU.cmake
-@@ -44,9 +44,8 @@
+@@ -59,9 +59,8 @@
    string(APPEND CMAKE_${lang}_FLAGS_RELWITHDEBINFO_INIT " -O2 -g -DNDEBUG")
    set(CMAKE_${lang}_CREATE_PREPROCESSED_SOURCE "<CMAKE_${lang}_COMPILER> <DEFINES> <INCLUDES> <FLAGS> -E <SOURCE> > <PREPROCESSED_SOURCE>")
    set(CMAKE_${lang}_CREATE_ASSEMBLY_SOURCE "<CMAKE_${lang}_COMPILER> <DEFINES> <INCLUDES> <FLAGS> -S <SOURCE> -o <ASSEMBLY_SOURCE>")

--- a/KEEP/cmake-lib64.patch
+++ b/KEEP/cmake-lib64.patch
@@ -1,20 +1,20 @@
 if sizeof void* is 33, then we deserve that our libs will be put into /lib64
 instead of /lib where they belong.
 
---- cmake-3.9.3.orig/Modules/GNUInstallDirs.cmake
-+++ cmake-3.9.3/Modules/GNUInstallDirs.cmake
-@@ -235,7 +235,7 @@
-           "Unable to determine default CMAKE_INSTALL_LIBDIR directory because no target architecture is known. "
-           "Please enable at least one language before including GNUInstallDirs.")
-       else()
--        if("${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
-+        if("${CMAKE_SIZEOF_VOID_P}" EQUAL "33")
-           set(_LIBDIR_DEFAULT "lib64")
-           if(DEFINED _GNUInstallDirs_LAST_CMAKE_INSTALL_PREFIX)
-             set(__LAST_LIBDIR_DEFAULT "lib64")
---- cmake-3.9.3.orig/Modules/Platform/Linux.cmake
-+++ cmake-3.9.3/Modules/Platform/Linux.cmake
-@@ -50,9 +50,6 @@
+--- a/Modules/GNUInstallDirs.cmake
++++ b/Modules/GNUInstallDirs.cmake
+@@ -251,7 +251,7 @@
+         endif()
+       endif()
+     else() # not debian, rely on CMAKE_SIZEOF_VOID_P:
+-      if("${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
++      if("${CMAKE_SIZEOF_VOID_P}" EQUAL "33")
+         set(_LIBDIR_DEFAULT "lib64")
+         if(DEFINED _GNUInstallDirs_LAST_CMAKE_INSTALL_PREFIX)
+           set(__LAST_LIBDIR_DEFAULT "lib64")
+--- a/Modules/Platform/Linux.cmake
++++ b/Modules/Platform/Linux.cmake
+@@ -51,9 +51,6 @@
  
  include(Platform/UnixPaths)
  

--- a/pkg/cmake
+++ b/pkg/cmake
@@ -1,10 +1,10 @@
 [mirrors]
-https://cmake.org/files/v3.9/cmake-3.9.3.tar.gz
+https://github.com/Kitware/CMake/releases/download/v3.20.3/cmake-3.20.3.tar.gz
 
 [vars]
-filesize=7705238
-sha512=30058cf4c154221846d1cd22eaf44a297d2a2d020a443f3e6f40384dfb86ee9a639a1299aa9f187f230505b2a6ee0fe69fbf5e80410711a6ac3d7a07b37f8dfc
-pkgver=2
+filesize=9440009
+sha512=ed2b8b04c759c4f7c5c363be33bf08e6677c710c1f937050a378ab5539136b919531e1c927b117b3d8d68d4bb613de8d92a3d4d50f3ab3bc98355febca779a1b
+pkgver=3
 desc='immensely bloated build tool mostly used by windows and C++ folks'
 
 [deps]

--- a/pkg/zig
+++ b/pkg/zig
@@ -1,17 +1,16 @@
 [mirrors]
-https://github.com/ziglang/zig-bootstrap/archive/refs/tags/0.7.1.tar.gz
+https://github.com/ziglang/zig-bootstrap/archive/refs/tags/0.8.0.tar.gz
 
 [vars]
-filesize=56987297
-sha512=8b7bfd1cf049878939453149c84894d36f1b11947302cbb4e475ab93dfeace7f5f8334b43bd210e1b728146da1171079f82f46bf05d06499a86ae16895d6b4a9
-pkgver=1
-tarball=zig-0.7.1.tar.gz
-tardir=zig-bootstrap-0.7.1
+filesize=62487949
+sha512=953165e56775555d6125459af7a8d06bff022c5627826a34e99c5d934ed39bacd8ffd5f725189367b0d6382e56a6b6826e00f0e142ddb5fa841060018465b171
+pkgver=2
+tarball=zig-0.8.0.tar.gz
+tardir=zig-bootstrap-0.8.0
 
-[deps]
-stage1
+[deps.host]
 cmake
-python
+python3
 
 [build]
 target=""


### PR DESCRIPTION
A cmake update was required in order to update the zig recipe. 