### PR TITLE
KEEP/butch_template_configure_cached.txt: Add check against the

### DIFF
--- a/KEEP/butch_template_configure_cached.txt
+++ b/KEEP/butch_template_configure_cached.txt
@@ -163,6 +163,14 @@ test "$USE_CCACHE" = 1 && type ccache >/dev/null 2>&1 && {
 	CXX="ccache $CXX"
 }
 
+if test -n "$SECURE_PACKAGES"; then
+	SECURE=0
+	for pkg in $SECURE_PACKAGES; do
+		test "$pkg" = "$butch_package_name" && SECURE=1 && break
+	done
+	export SECURE
+fi
+
 debug_build=false
 if [ -f "$butch_root_dir"/etc/butch-optflags.sh ] ; then
 	user_optimizations_file="$butch_root_dir"/etc/butch-optflags.sh


### PR DESCRIPTION
SECURE_PACKAGES env. variable.

This setting allows you to definitively define which packages you'd like to build against SECURE=1; and also allows to upgrade secure and non-secure packages in one shot.