### PR TITLE
Resolve reproducible build issues

### DIFF
--- a/KEEP/butch_template_configure_cached.txt
+++ b/KEEP/butch_template_configure_cached.txt
@@ -366,7 +366,7 @@ if $have_files ; then
 			compressor="gzip"
 			ext=.gz
 		fi
-		if type xz >/dev/null 2>&1 && ! xz --help 2>&1 | grep BusyBox>/dev/null 2>&1 ; then
+		if type xz >/dev/null 2>&1 && ! xz --help 2>&1 | grep BusyBox>/dev/null 2>&1 && xz -z </dev/null >/dev/null 2>&1 ; then
 			compressor="xz -z"
 			ext=.xz
 		fi

--- a/pkg/busybox
+++ b/pkg/busybox
@@ -50,7 +50,7 @@ fi
 
 [ -z "$HOSTCC" ] && HOSTCC="$CC"
 
-make HOSTCC="$HOSTCC" KCONFIG_ALLCONFIG=config.stage1 allnoconfig
+make HOSTCC="$HOSTCC" KCONFIG_ALLCONFIG=config.stage1 KCONFIG_NOTIMESTAMP=1 allnoconfig
 
 # alternative:
 # make KBUILD_VERBOSE=1 CC="$CC" HOSTCC="$HOSTCC" \

--- a/pkg/kernel-headers
+++ b/pkg/kernel-headers
@@ -19,5 +19,6 @@ dest="$butch_install_dir""$butch_prefix"
 #fix ext2 header...
 install -Dm 644 "$K"/ext2_fs.h "$dest"/include/linux/
 #fix swab header
-sed -i '4a\\n#include <linux/stddef.h>\n' "$dest"/include/linux/swab.h
+sed -i '4a\
+\n#include <linux/stddef.h>\n' "$dest"/include/linux/swab.h
 

--- a/utils/clean-stage1.sh
+++ b/utils/clean-stage1.sh
@@ -11,7 +11,7 @@ export CONFIG
 [ "$R" = "/" ] && R=
 [ -z "$BUTCHDB" ] && BUTCHDB=$R/var/lib/butch.db
 
-for pkg in gcc3 gcc424 stage0-gcc424 stage1-gcc424 stage0-gcc3 stage1-gcc3 stage0-musl; do
+for pkg in gcc3 gcc424 stage0-gcc424 stage1-gcc424 stage0-gcc3 stage1-gcc3 stage0-musl bearssl; do
 	"$K"/bin/butch-rm "$pkg" > /dev/null
 done
 

--- a/utils/rebuild-stage1.sh
+++ b/utils/rebuild-stage1.sh
@@ -33,6 +33,7 @@ e2fsprogs
 man
 libressl
 ca-certificates
+curl
 '
 
 pkg="$base_pkg"


### PR DESCRIPTION
@rofl0r This should resolve those issues you noticed with the bootsh bootstrap producing different checksums to the normal bootstrap path. I ran both through to rebuild-stage1, and confirmed with diffoscope that the `/opt` directories of each are identical now.